### PR TITLE
Jenkins & GHA default-from-toml

### DIFF
--- a/GitHub-Actions/two-stage-pipeline-template/hooks/post_gen_project.py
+++ b/GitHub-Actions/two-stage-pipeline-template/hooks/post_gen_project.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from pathlib import Path
 
 output_dir = "{{ cookiecutter.outputDir }}"
@@ -19,4 +20,4 @@ if destination_file.exists():
 os.rename(workflow_file_name, destination_file)
 
 # There is only one file in output_dir, remove it
-os.rmdir(Path.cwd().resolve())
+shutil.rmtree(Path.cwd().resolve())

--- a/GitHub-Actions/two-stage-pipeline-template/questions.json
+++ b/GitHub-Actions/two-stage-pipeline-template/questions.json
@@ -33,55 +33,49 @@
     "key": "testing_pipeline_execution_role",
     "question": "What is the testing pipeline execution role ARN?",
     "isRequired": true,
-    "default_from_toml": {
-      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
-      "env": { "valueof": "testing_stage_name"},
-      "cmd_names": "pipeline_bootstrap",
-      "section": "parameters",
-      "key": "pipeline_execution_role"
+    "default": {
+      "keyPath": [
+          { "valueof": "testing_stage_name"},
+          "pipeline_execution_role"
+      ]
     }
   }, {
     "key": "testing_cloudformation_execution_role",
     "question": "What is the testing CloudFormation execution role ARN?",
     "isRequired": true,
-    "default_from_toml": {
-      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
-      "env": { "valueof": "testing_stage_name"},
-      "cmd_names": "pipeline_bootstrap",
-      "section": "parameters",
-      "key": "cloudformation_execution_role"
+    "default": {
+      "keyPath": [
+          { "valueof": "testing_stage_name"},
+          "cloudformation_execution_role"
+      ]
     }
   }, {
     "key": "testing_artifacts_bucket",
     "question": "What is the testing S3 bucket name for artifacts?",
     "isRequired": true,
-    "default_from_toml": {
-      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
-      "env": { "valueof": "testing_stage_name"},
-      "cmd_names": "pipeline_bootstrap",
-      "section": "parameters",
-      "key": "artifacts_bucket"
+    "default": {
+      "keyPath": [
+          { "valueof": "testing_stage_name"},
+          "artifacts_bucket"
+      ]
     }
   }, {
     "key": "testing_ecr_repo",
     "question": "What is the testing ECR repository URI?",
-    "default_from_toml": {
-      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
-      "env": { "valueof": "testing_stage_name"},
-      "cmd_names": "pipeline_bootstrap",
-      "section": "parameters",
-      "key": "ecr_repo"
+    "default": {
+      "keyPath": [
+          { "valueof": "testing_stage_name"},
+          "ecr_repo"
+      ]
     }
   }, {
     "key": "testing_region",
     "question": "What is the testing AWS region?",
-    "default": "us-east-2",
-    "default_from_toml": {
-      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
-      "env": { "valueof": "testing_stage_name"},
-      "cmd_names": "pipeline_bootstrap",
-      "section": "parameters",
-      "key": "region"
+    "default": {
+      "keyPath": [
+          { "valueof": "testing_stage_name"},
+          "region"
+      ]
     }
   }, {
     "key": "prod_stage_name",
@@ -95,55 +89,49 @@
     "key": "prod_pipeline_execution_role",
     "question": "What is the production pipeline execution role ARN?",
     "isRequired": true,
-    "default_from_toml": {
-      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
-      "env": { "valueof": "prod_stage_name"},
-      "cmd_names": "pipeline_bootstrap",
-      "section": "parameters",
-      "key": "pipeline_execution_role"
+    "default": {
+      "keyPath": [
+          { "valueof": "prod_stage_name"},
+          "pipeline_execution_role"
+      ]
     }
   }, {
     "key": "prod_cloudformation_execution_role",
     "question": "What is the production CloudFormation execution role ARN?",
     "isRequired": true,
-    "default_from_toml": {
-      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
-      "env": { "valueof": "prod_stage_name"},
-      "cmd_names": "pipeline_bootstrap",
-      "section": "parameters",
-      "key": "cloudformation_execution_role"
+    "default": {
+      "keyPath": [
+          { "valueof": "prod_stage_name"},
+          "cloudformation_execution_role"
+      ]
     }
   }, {
     "key": "prod_artifacts_bucket",
     "question": "What is the production S3 bucket name for artifacts?",
     "isRequired": true,
-    "default_from_toml": {
-      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
-      "env": { "valueof": "prod_stage_name"},
-      "cmd_names": "pipeline_bootstrap",
-      "section": "parameters",
-      "key": "artifacts_bucket"
+    "default": {
+      "keyPath": [
+          { "valueof": "prod_stage_name"},
+          "artifacts_bucket"
+      ]
     }
   }, {
     "key": "prod_ecr_repo",
     "question": "What is the production ECR repository URI?",
-    "default_from_toml": {
-      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
-      "env": { "valueof": "prod_stage_name"},
-      "cmd_names": "pipeline_bootstrap",
-      "section": "parameters",
-      "key": "ecr_repo"
+    "default": {
+      "keyPath": [
+          { "valueof": "prod_stage_name"},
+          "ecr_repo"
+      ]
     }
   }, {
     "key": "prod_region",
     "question": "What is the production AWS region?",
-    "default": "us-east-2",
-    "default_from_toml": {
-      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
-      "env": { "valueof": "prod_stage_name"},
-      "cmd_names": "pipeline_bootstrap",
-      "section": "parameters",
-      "key": "region"
+    "default": {
+      "keyPath": [
+          { "valueof": "prod_stage_name"},
+          "region"
+      ]
     }
   }]
 }

--- a/GitHub-Actions/two-stage-pipeline-template/questions.json
+++ b/GitHub-Actions/two-stage-pipeline-template/questions.json
@@ -16,28 +16,77 @@
     "question": "What is the template file path?",
     "default": "template.yaml"
   }, {
+    "key": "message_testing_stage_name",
+    "question": "We use the stage name to automatically retrieve the bootstrapped resources created when you ran `sam pipeline bootstrap`",
+    "kind": "info"
+  }, {
+    "key": "testing_stage_name",
+    "question": "What is the testing stage name (as provided during the bootstrapping) ?",
+    "isRequired": true,
+    "default": "testing"
+  }, {
     "key": "testing_stack_name",
     "question": "What is the testing stack name?",
-    "isRequired": true
+    "isRequired": true,
+    "default": "testing"
   }, {
     "key": "testing_pipeline_execution_role",
     "question": "What is the testing pipeline execution role ARN?",
-    "isRequired": true
+    "isRequired": true,
+    "default_from_toml": {
+      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
+      "env": { "valueof": "testing_stage_name"},
+      "cmd_names": "pipeline_bootstrap",
+      "section": "parameters",
+      "key": "pipeline_execution_role"
+    }
   }, {
     "key": "testing_cloudformation_execution_role",
     "question": "What is the testing CloudFormation execution role ARN?",
-    "isRequired": true
+    "isRequired": true,
+    "default_from_toml": {
+      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
+      "env": { "valueof": "testing_stage_name"},
+      "cmd_names": "pipeline_bootstrap",
+      "section": "parameters",
+      "key": "cloudformation_execution_role"
+    }
   }, {
     "key": "testing_artifacts_bucket",
     "question": "What is the testing S3 bucket name for artifacts?",
-    "isRequired": true
+    "isRequired": true,
+    "default_from_toml": {
+      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
+      "env": { "valueof": "testing_stage_name"},
+      "cmd_names": "pipeline_bootstrap",
+      "section": "parameters",
+      "key": "artifacts_bucket"
+    }
   }, {
     "key": "testing_ecr_repo",
     "question": "What is the testing ECR repository URI?",
+    "default_from_toml": {
+      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
+      "env": { "valueof": "testing_stage_name"},
+      "cmd_names": "pipeline_bootstrap",
+      "section": "parameters",
+      "key": "ecr_repo"
+    }
   }, {
     "key": "testing_region",
     "question": "What is the testing AWS region?",
-    "default": "us-east-2"
+    "default": "us-east-2",
+    "default_from_toml": {
+      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
+      "env": { "valueof": "testing_stage_name"},
+      "cmd_names": "pipeline_bootstrap",
+      "section": "parameters",
+      "key": "region"
+    }
+  }, {
+    "key": "prod_stage_name",
+    "question": "What is the production stage name?",
+    "isRequired": true
   }, {
     "key": "prod_stack_name",
     "question": "What is the production stack name?",
@@ -45,21 +94,56 @@
   }, {
     "key": "prod_pipeline_execution_role",
     "question": "What is the production pipeline execution role ARN?",
-    "isRequired": true
+    "isRequired": true,
+    "default_from_toml": {
+      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
+      "env": { "valueof": "prod_stage_name"},
+      "cmd_names": "pipeline_bootstrap",
+      "section": "parameters",
+      "key": "pipeline_execution_role"
+    }
   }, {
     "key": "prod_cloudformation_execution_role",
     "question": "What is the production CloudFormation execution role ARN?",
-    "isRequired": true
+    "isRequired": true,
+    "default_from_toml": {
+      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
+      "env": { "valueof": "prod_stage_name"},
+      "cmd_names": "pipeline_bootstrap",
+      "section": "parameters",
+      "key": "cloudformation_execution_role"
+    }
   }, {
     "key": "prod_artifacts_bucket",
     "question": "What is the production S3 bucket name for artifacts?",
-    "isRequired": true
+    "isRequired": true,
+    "default_from_toml": {
+      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
+      "env": { "valueof": "prod_stage_name"},
+      "cmd_names": "pipeline_bootstrap",
+      "section": "parameters",
+      "key": "artifacts_bucket"
+    }
   }, {
     "key": "prod_ecr_repo",
     "question": "What is the production ECR repository URI?",
+    "default_from_toml": {
+      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
+      "env": { "valueof": "prod_stage_name"},
+      "cmd_names": "pipeline_bootstrap",
+      "section": "parameters",
+      "key": "ecr_repo"
+    }
   }, {
     "key": "prod_region",
     "question": "What is the production AWS region?",
-    "default": "us-east-2"
+    "default": "us-east-2",
+    "default_from_toml": {
+      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
+      "env": { "valueof": "prod_stage_name"},
+      "cmd_names": "pipeline_bootstrap",
+      "section": "parameters",
+      "key": "region"
+    }
   }]
 }

--- a/Gitlab/two-stage-pipeline-template/cookiecutter.json
+++ b/Gitlab/two-stage-pipeline-template/cookiecutter.json
@@ -1,0 +1,18 @@
+{
+  "outputDir": "aws-sam-pipeline",
+  "main_git_branch": "",
+  "sam_template": "",
+  "testing_stack_name": "",
+  "testing_pipeline_execution_role": "",
+  "testing_cloudformation_execution_role": "",
+  "testing_artifacts_bucket": "",
+  "testing_ecr_repo": "",
+  "testing_region": "",
+  "prod_stack_name": "",
+  "prod_pipeline_execution_role": "",
+  "prod_cloudformation_execution_role": "",
+  "prod_artifacts_bucket":  "",
+  "prod_ecr_repo":  "",
+  "prod_region": ""
+}
+

--- a/Gitlab/two-stage-pipeline-template/hooks/post_gen_project.py
+++ b/Gitlab/two-stage-pipeline-template/hooks/post_gen_project.py
@@ -1,0 +1,24 @@
+import os
+import shutil
+
+output_dir = "{{ cookiecutter.outputDir }}"
+project_root_dir = os.path.relpath(".", output_dir)
+gitlab_file = ".gitlab-ci.yml"
+assume_role_file = "assume-role.sh"
+
+# move ".gitlab-ci.yml" and "assume-role.sh" to the root of the project
+gitlab_file_path = os.path.join(project_root_dir, gitlabFile)
+assume_role_file_path = os.path.join(project_root_dir, assumeRoleFile)
+if os.path.exists(gitlab_file_path):
+    raise Exception(
+        f"{gitlab_file} already exists in project root directory. Please remove it first."
+    )
+if os.path.exists(assume_role_file_path):
+    raise Exception(
+        f"{assume_role_file} already exists in project root directory. Please remove it first."
+    )
+
+os.rename(gitlab_file, os.path.join(project_root_dir, gitlab_file))
+os.rename(assume_role_file, os.path.join(project_root_dir, assume_role_file))
+
+shutil.rmtree(os.path.join(project_root_dir, output_dir))

--- a/Gitlab/two-stage-pipeline-template/questions.json
+++ b/Gitlab/two-stage-pipeline-template/questions.json
@@ -1,0 +1,57 @@
+{
+  "questions": [{
+    "key": "main_git_branch",
+    "question": "What is the git branch used for production deployments?",
+    "default": "main"
+  }, {
+    "key": "sam_template",
+    "question": "What is the template file path?",
+    "default": "template.yaml"
+  }, {
+    "key": "testing_stack_name",
+    "question": "What is the testing stack name?",
+    "isRequired": true
+  }, {
+    "key": "testing_pipeline_execution_role",
+    "question": "What is the testing pipeline execution role ARN?",
+    "isRequired": true
+  }, {
+    "key": "testing_cloudformation_execution_role",
+    "question": "What is the testing CloudFormation execution role ARN?",
+    "isRequired": true
+  }, {
+    "key": "testing_artifacts_bucket",
+    "question": "What is the testing S3 bucket name for artifacts?",
+    "isRequired": true
+  }, {
+    "key": "testing_ecr_repo",
+    "question": "What is the testing ECR repository URI?",
+  }, {
+    "key": "testing_region",
+    "question": "What is the testing AWS region?",
+    "default": "us-east-2"
+  }, {
+    "key": "prod_stack_name",
+    "question": "What is the production stack name?",
+    "isRequired": true
+  }, {
+    "key": "prod_pipeline_execution_role",
+    "question": "What is the production pipeline execution role ARN?",
+    "isRequired": true
+  }, {
+    "key": "prod_cloudformation_execution_role",
+    "question": "What is the production CloudFormation execution role ARN?",
+    "isRequired": true
+  }, {
+    "key": "prod_artifacts_bucket",
+    "question": "What is the production S3 bucket name for artifacts?",
+    "isRequired": true
+  }, {
+    "key": "prod_ecr_repo",
+    "question": "What is the production ECR repository URI?",
+  }, {
+    "key": "prod_region",
+    "question": "What is the production AWS region?",
+    "default": "us-east-2"
+  }]
+}

--- a/Gitlab/two-stage-pipeline-template/questions.json
+++ b/Gitlab/two-stage-pipeline-template/questions.json
@@ -8,28 +8,69 @@
     "question": "What is the template file path?",
     "default": "template.yaml"
   }, {
+    "key": "message_testing_stage_name",
+    "question": "We use the stage name to automatically retrieve the bootstrapped resources created when you ran `sam pipeline bootstrap`",
+    "kind": "info"
+  }, {
+    "key": "testing_stage_name",
+    "question": "What is the testing stage name (as provided during the bootstrapping) ?",
+    "isRequired": true
+  }, {
     "key": "testing_stack_name",
     "question": "What is the testing stack name?",
     "isRequired": true
   }, {
     "key": "testing_pipeline_execution_role",
     "question": "What is the testing pipeline execution role ARN?",
-    "isRequired": true
+    "isRequired": true,
+    "default": {
+      "keyPath": [
+          { "valueof": "testing_stage_name"},
+          "pipeline_execution_role"
+      ]
+    }
   }, {
     "key": "testing_cloudformation_execution_role",
     "question": "What is the testing CloudFormation execution role ARN?",
-    "isRequired": true
+    "isRequired": true,
+    "default": {
+      "keyPath": [
+          { "valueof": "testing_stage_name"},
+          "cloudformation_execution_role"
+      ]
+    }
   }, {
     "key": "testing_artifacts_bucket",
     "question": "What is the testing S3 bucket name for artifacts?",
-    "isRequired": true
+    "isRequired": true,
+    "default": {
+      "keyPath": [
+          { "valueof": "testing_stage_name"},
+          "artifacts_bucket"
+      ]
+    }
   }, {
     "key": "testing_ecr_repo",
     "question": "What is the testing ECR repository URI?",
+    "default": {
+      "keyPath": [
+          { "valueof": "testing_stage_name"},
+          "ecr_repo"
+      ]
+    }
   }, {
     "key": "testing_region",
     "question": "What is the testing AWS region?",
-    "default": "us-east-2"
+    "default": {
+      "keyPath": [
+          { "valueof": "testing_stage_name"},
+          "region"
+      ]
+    }
+  }, {
+    "key": "prod_stage_name",
+    "question": "What is the production stage name?",
+    "isRequired": true
   }, {
     "key": "prod_stack_name",
     "question": "What is the production stack name?",
@@ -37,21 +78,50 @@
   }, {
     "key": "prod_pipeline_execution_role",
     "question": "What is the production pipeline execution role ARN?",
-    "isRequired": true
+    "isRequired": true,
+    "default": {
+      "keyPath": [
+          { "valueof": "prod_stage_name"},
+          "pipeline_execution_role"
+      ]
+    }
   }, {
     "key": "prod_cloudformation_execution_role",
     "question": "What is the production CloudFormation execution role ARN?",
-    "isRequired": true
+    "isRequired": true,
+    "default": {
+      "keyPath": [
+          { "valueof": "prod_stage_name"},
+          "cloudformation_execution_role"
+      ]
+    }
   }, {
     "key": "prod_artifacts_bucket",
     "question": "What is the production S3 bucket name for artifacts?",
-    "isRequired": true
+    "isRequired": true,
+    "default": {
+      "keyPath": [
+          { "valueof": "prod_stage_name"},
+          "artifacts_bucket"
+      ]
+    }
   }, {
     "key": "prod_ecr_repo",
     "question": "What is the production ECR repository URI?",
+    "default": {
+      "keyPath": [
+          { "valueof": "prod_stage_name"},
+          "ecr_repo"
+      ]
+    }
   }, {
     "key": "prod_region",
     "question": "What is the production AWS region?",
-    "default": "us-east-2"
+    "default": {
+      "keyPath": [
+          { "valueof": "prod_stage_name"},
+          "region"
+      ]
+    }
   }]
 }

--- a/Gitlab/two-stage-pipeline-template/{{cookiecutter.outputDir}}/.gitlab-ci.yml
+++ b/Gitlab/two-stage-pipeline-template/{{cookiecutter.outputDir}}/.gitlab-ci.yml
@@ -1,0 +1,170 @@
+variables:
+  SAM_TEMPLATE: {{cookiecutter.sam_template}}
+  PIPELINE_USER_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+  PIPELINE_USER_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+  TESTING_STACK_NAME: {{cookiecutter.testing_stack_name}}
+  TESTING_REGION: {{cookiecutter.testing_region}}
+  TESTING_PIPELINE_EXECUTION_ROLE: {{cookiecutter.testing_pipeline_execution_role}}
+  TESTING_CLOUDFORMATION_EXECUTION_ROLE: {{cookiecutter.testing_cloudformation_execution_role}}
+  TESTING_ARTIFACTS_BUCKET: {{cookiecutter.testing_artifacts_bucket}}
+  {%- if cookiecutter.testing_ecr_repo %}
+  TESTING_ECR_REPO: {{cookiecutter.testing_ecr_repo}}
+  {% else %}
+  # If there are functions with "Image" PackageType in your template,
+  # uncomment the line below and add "--image-repository ${TESTING_ECR_REPO}" to
+  # testing "sam package" and "sam deploy" commands.'
+  # TESTING_ECR_REPO = '0123456789.dkr.ecr.region.amazonaws.com/repository-name'
+  {% endif -%}
+  PROD_STACK_NAME: {{cookiecutter.prod_stack_name}}
+  PROD_REGION: {{cookiecutter.prod_region}}
+  PROD_PIPELINE_EXECUTION_ROLE: {{cookiecutter.prod_pipeline_execution_role}}
+  PROD_CLOUDFORMATION_EXECUTION_ROLE: {{cookiecutter.prod_cloudformation_execution_role}}
+  PROD_ARTIFACTS_BUCKET: {{cookiecutter.prod_artifacts_bucket}}
+  {%- if cookiecutter.prod_ecr_repo %}
+  PROD_ECR_REPO: {{cookiecutter.prod_ecr_repo}}
+  {% else %}
+  # If there are functions with "Image" PackageType in your template,
+  # uncomment the line below and add "--image-repository ${PROD_ECR_REPO}" to
+  # prod "sam package" and "sam deploy" commands.'
+  # PROD_ECR_REPO = '0123456789.dkr.ecr.region.amazonaws.com/repository-name'
+  {% endif -%}
+  # By default, when using docker:dind, Docker uses the vfs storage
+  # driver which copies the file system on every run.
+  # This is a disk-intensive operation which can be avoided if a different driver is used.
+  # For example overlay2
+  DOCKER_DRIVER: overlay2
+  # Create the certificates inside this directory for both the server
+  # and client. The certificates used by the client will be created in
+  # /certs/client so we only need to share this directory with the
+  # volume mount in `config.toml`.
+  DOCKER_TLS_CERTDIR: "/certs"
+
+# Should always specify a specific version of the image. If using a tag like docker:stable,
+# there will be no control over which version is used. Unpredictable behavior can result.
+image: docker:19.03.15
+
+services:
+    - docker:19.03.15-dind
+
+before_script:
+  - apk add --update python3 py-pip python3-dev build-base
+  - pip install awscli aws-sam-cli
+
+stages:
+  - unit-test
+  - build
+  - testing
+  - prod
+
+# uncomment and modify the following step for running the unit-tests
+#
+#unit-test:
+#  stage: unit-test
+#  only:
+#    - {{cookiecutter.main_git_branch}}
+#    - /^feature-.*$/
+#  script: |
+
+# This stage is triggered only for feature branches (feature*),
+# which will build the stack and deploy to a stack named with branch name.
+build-and-deploy-feature:
+  stage: build
+  only:
+    - /^feature-.*$/
+  script:
+    - . {{cookiecutter.outputDir}}/assume-role.sh ${TESTING_REGION}
+                                                  ${TESTING_PIPELINE_EXECUTION_ROLE}
+                                                  feature-deployment
+    - sam build --template ${SAM_TEMPLATE} --use-container
+    - sam deploy --stack-name features-${CI_COMMIT_REF_NAME}-cfn-stack
+                 --capabilities CAPABILITY_IAM
+                 --region ${TESTING_REGION}
+                 --s3-bucket ${TESTING_ARTIFACTS_BUCKET}
+                 {%- if cookiecutter.testing_ecr_repo %}
+                 --image-repository ${TESTING_ECR_REPO}
+                 {%- endif %}
+                 --no-fail-on-empty-changeset
+                 --role-arn ${TESTING_CLOUDFORMATION_EXECUTION_ROLE}
+
+# This stage is triggered for main branch you set in the question,
+# which will build the stack, package the application, upload the
+# applications artifacts to Amazon S3 and output the SAM template file.
+build-and-package:
+  stage: build
+  only:
+    - {{cookiecutter.main_git_branch}}
+  script:
+    - sam build --template ${SAM_TEMPLATE} --use-container
+
+    - . {{cookiecutter.outputDir}}/assume-role.sh ${TESTING_REGION}
+                                                  ${TESTING_PIPELINE_EXECUTION_ROLE}
+                                                  testing-stage-packaging
+
+    - sam package --s3-bucket ${TESTING_ARTIFACTS_BUCKET}
+                   {%- if cookiecutter.testing_ecr_repo %}
+                   --image-repository ${TESTING_ECR_REPO}
+                   {%- endif %}
+                   --region ${TESTING_REGION}
+                   --output-template-file packaged-testing.yaml
+
+    - . {{cookiecutter.outputDir}}/assume-role.sh ${PROD_REGION}
+                                                  ${PROD_PIPELINE_EXECUTION_ROLE}
+                                                  prod-stage-packaging
+
+    - sam package --s3-bucket ${PROD_ARTIFACTS_BUCKET}
+                  {%- if cookiecutter.prod_ecr_repo %}
+                  --image-repository ${PROD_ECR_REPO}
+                  {%- endif %}
+                  --region ${PROD_REGION}
+                  --output-template-file packaged-prod.yaml
+
+  artifacts:
+    paths:
+      - packaged-testing.yaml
+      - packaged-prod.yaml
+
+# This stage is triggered for main branch you set in the question,
+# which will deploy the SAM application to testing environment using
+# the templated file generated.
+deploy-testing:
+  stage: testing
+  only:
+    - {{cookiecutter.main_git_branch}}
+  script:
+    - . {{cookiecutter.outputDir}}/assume-role.sh ${TESTING_REGION}
+                                                  ${TESTING_PIPELINE_EXECUTION_ROLE}
+                                                  testing-deployment
+    - sam deploy --stack-name ${TESTING_STACK_NAME}
+                 --template packaged-testing.yaml
+                 --capabilities CAPABILITY_IAM
+                 --region ${TESTING_REGION}
+                 --s3-bucket ${TESTING_ARTIFACTS_BUCKET}
+                 {%- if cookiecutter.testing_ecr_repo %}
+                 --image-repository ${TESTING_ECR_REPO}
+                 {%- endif %}
+                 --no-fail-on-empty-changeset
+                 --role-arn ${TESTING_CLOUDFORMATION_EXECUTION_ROLE}
+
+# This stage is triggered for main branch you set in the question,
+# which will deploy the SAM application to prod environment using
+# the templated file generated.
+deploy-prod:
+  stage: prod
+  # uncomment this to have a manual approval step before deployment to production
+  # when: manual
+  only:
+    - {{cookiecutter.main_git_branch}}
+  script:
+    - . {{cookiecutter.outputDir}}/assume-role.sh ${PROD_REGION}
+                                                  ${PROD_PIPELINE_EXECUTION_ROLE}
+                                                  prod-deployment
+    - sam deploy --stack-name ${PROD_STACK_NAME}
+                 --template packaged-prod.yaml
+                 --capabilities CAPABILITY_IAM
+                 --region ${PROD_REGION}
+                 --s3-bucket ${PROD_ARTIFACTS_BUCKET}
+                 {%- if cookiecutter.prod_ecr_repo %}
+                 --image-repository ${PROD_ECR_REPO}
+                 {%- endif %}
+                 --no-fail-on-empty-changeset
+                 --role-arn ${PROD_CLOUDFORMATION_EXECUTION_ROLE}

--- a/Gitlab/two-stage-pipeline-template/{{cookiecutter.outputDir}}/assume-role.sh
+++ b/Gitlab/two-stage-pipeline-template/{{cookiecutter.outputDir}}/assume-role.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+REGION=$1
+ROLE=$2
+SESSION_NAME=$3
+
+unset AWS_SESSION_TOKEN
+export AWS_DEFAULT_REGION=$REGION
+export AWS_ACCESS_KEY_ID=$PIPELINE_USER_ACCESS_KEY_ID
+export AWS_SECRET_ACCESS_KEY=$PIPELINE_USER_SECRET_ACCESS_KEY
+
+cred=$(aws sts assume-role --role-arn "$ROLE" \
+                           --role-session-name "$SESSION_NAME" \
+                           --query '[Credentials.AccessKeyId,Credentials.SecretAccessKey,Credentials.SessionToken]' \
+                           --output text)
+
+ACCESS_KEY_ID=$(echo "$cred" | awk '{ print $1 }')
+export AWS_ACCESS_KEY_ID=$ACCESS_KEY_ID
+
+SECRET_ACCESS_KEY=$(echo "$cred" | awk '{ print $2 }')
+export AWS_SECRET_ACCESS_KEY=$SECRET_ACCESS_KEY
+
+SESSION_TOKEN=$(echo "$cred" | awk '{ print $3 }')
+export AWS_SESSION_TOKEN=$SESSION_TOKEN

--- a/Jenkins/two-stage-pipeline-template/hooks/post_gen_project.py
+++ b/Jenkins/two-stage-pipeline-template/hooks/post_gen_project.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 
 output_dir = "{{ cookiecutter.outputDir }}"
 project_root_dir = os.path.relpath(".", output_dir)
@@ -14,4 +15,4 @@ if os.path.exists(destination_file_path):
 os.rename(jenkinsfile, os.path.join(project_root_dir, jenkinsfile))
 
 # There is only one file in output_dir, remove it
-os.rmdir(os.path.join(project_root_dir, output_dir))
+shutil.rmtree(os.path.join(project_root_dir, output_dir))

--- a/Jenkins/two-stage-pipeline-template/questions.json
+++ b/Jenkins/two-stage-pipeline-template/questions.json
@@ -12,28 +12,76 @@
     "question": "What is the template file path?",
     "default": "template.yaml"
   }, {
+    "key": "message_testing_stage_name",
+    "question": "We use the stage name to automatically retrieve the bootstrapped resources created when you ran `sam pipeline bootstrap`",
+    "kind": "info"
+  }, {
+    "key": "testing_stage_name",
+    "question": "What is the testing stage name (as provided during the bootstrapping) ?",
+    "isRequired": true,
+    "default": "testing"
+  }, {
     "key": "testing_stack_name",
     "question": "What is the testing stack name?",
     "isRequired": true
   }, {
     "key": "testing_pipeline_execution_role",
     "question": "What is the testing pipeline execution role ARN?",
-    "isRequired": true
+    "isRequired": true,
+    "default_from_toml": {
+      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
+      "env": { "valueof": "testing_stage_name"},
+      "cmd_names": "pipeline_bootstrap",
+      "section": "parameters",
+      "key": "pipeline_execution_role"
+    }
   }, {
     "key": "testing_cloudformation_execution_role",
     "question": "What is the testing CloudFormation execution role ARN?",
-    "isRequired": true
+    "isRequired": true,
+    "default_from_toml": {
+      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
+      "env": { "valueof": "testing_stage_name"},
+      "cmd_names": "pipeline_bootstrap",
+      "section": "parameters",
+      "key": "cloudformation_execution_role"
+    }
   }, {
     "key": "testing_artifacts_bucket",
     "question": "What is the testing S3 bucket name for artifacts?",
-    "isRequired": true
+    "isRequired": true,
+    "default_from_toml": {
+      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
+      "env": { "valueof": "testing_stage_name"},
+      "cmd_names": "pipeline_bootstrap",
+      "section": "parameters",
+      "key": "artifacts_bucket"
+    }
   }, {
     "key": "testing_ecr_repo",
     "question": "What is the testing ECR repository URI?",
+    "default_from_toml": {
+      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
+      "env": { "valueof": "testing_stage_name"},
+      "cmd_names": "pipeline_bootstrap",
+      "section": "parameters",
+      "key": "ecr_repo"
+    }
   }, {
     "key": "testing_region",
     "question": "What is the testing AWS region?",
-    "default": "us-east-2"
+    "default": "us-east-2",
+    "default_from_toml": {
+      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
+      "env": { "valueof": "testing_stage_name"},
+      "cmd_names": "pipeline_bootstrap",
+      "section": "parameters",
+      "key": "region"
+    }
+  }, {
+    "key": "prod_stage_name",
+    "question": "What is the production stage name?",
+    "isRequired": true
   }, {
     "key": "prod_stack_name",
     "question": "What is the production stack name?",
@@ -41,21 +89,56 @@
   }, {
     "key": "prod_pipeline_execution_role",
     "question": "What is the production pipeline execution role ARN?",
-    "isRequired": true
+    "isRequired": true,
+    "default_from_toml": {
+      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
+      "env": { "valueof": "prod_stage_name"},
+      "cmd_names": "pipeline_bootstrap",
+      "section": "parameters",
+      "key": "pipeline_execution_role"
+    }
   }, {
     "key": "prod_cloudformation_execution_role",
     "question": "What is the production CloudFormation execution role ARN?",
-    "isRequired": true
+    "isRequired": true,
+    "default_from_toml": {
+      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
+      "env": { "valueof": "prod_stage_name"},
+      "cmd_names": "pipeline_bootstrap",
+      "section": "parameters",
+      "key": "cloudformation_execution_role"
+    }
   }, {
     "key": "prod_artifacts_bucket",
     "question": "What is the production S3 bucket name for artifacts?",
-    "isRequired": true
+    "isRequired": true,
+    "default_from_toml": {
+      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
+      "env": { "valueof": "prod_stage_name"},
+      "cmd_names": "pipeline_bootstrap",
+      "section": "parameters",
+      "key": "artifacts_bucket"
+    }
   }, {
     "key": "prod_ecr_repo",
     "question": "What is the production ECR repository URI?",
+    "default_from_toml": {
+      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
+      "env": { "valueof": "prod_stage_name"},
+      "cmd_names": "pipeline_bootstrap",
+      "section": "parameters",
+      "key": "ecr_repo"
+    }
   }, {
     "key": "prod_region",
     "question": "What is the production AWS region?",
-    "default": "us-east-2"
+    "default": "us-east-2",
+    "default_from_toml": {
+      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
+      "env": { "valueof": "prod_stage_name"},
+      "cmd_names": "pipeline_bootstrap",
+      "section": "parameters",
+      "key": "region"
+    }
   }]
 }

--- a/Jenkins/two-stage-pipeline-template/questions.json
+++ b/Jenkins/two-stage-pipeline-template/questions.json
@@ -28,55 +28,49 @@
     "key": "testing_pipeline_execution_role",
     "question": "What is the testing pipeline execution role ARN?",
     "isRequired": true,
-    "default_from_toml": {
-      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
-      "env": { "valueof": "testing_stage_name"},
-      "cmd_names": "pipeline_bootstrap",
-      "section": "parameters",
-      "key": "pipeline_execution_role"
+    "default": {
+      "keyPath": [
+          { "valueof": "testing_stage_name"},
+          "pipeline_execution_role"
+      ]
     }
   }, {
     "key": "testing_cloudformation_execution_role",
     "question": "What is the testing CloudFormation execution role ARN?",
     "isRequired": true,
-    "default_from_toml": {
-      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
-      "env": { "valueof": "testing_stage_name"},
-      "cmd_names": "pipeline_bootstrap",
-      "section": "parameters",
-      "key": "cloudformation_execution_role"
+    "default": {
+      "keyPath": [
+          { "valueof": "testing_stage_name"},
+          "cloudformation_execution_role"
+      ]
     }
   }, {
     "key": "testing_artifacts_bucket",
     "question": "What is the testing S3 bucket name for artifacts?",
     "isRequired": true,
-    "default_from_toml": {
-      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
-      "env": { "valueof": "testing_stage_name"},
-      "cmd_names": "pipeline_bootstrap",
-      "section": "parameters",
-      "key": "artifacts_bucket"
+    "default": {
+      "keyPath": [
+          { "valueof": "testing_stage_name"},
+          "artifacts_bucket"
+      ]
     }
   }, {
     "key": "testing_ecr_repo",
     "question": "What is the testing ECR repository URI?",
-    "default_from_toml": {
-      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
-      "env": { "valueof": "testing_stage_name"},
-      "cmd_names": "pipeline_bootstrap",
-      "section": "parameters",
-      "key": "ecr_repo"
+    "default": {
+      "keyPath": [
+          { "valueof": "testing_stage_name"},
+          "ecr_repo"
+      ]
     }
   }, {
     "key": "testing_region",
     "question": "What is the testing AWS region?",
-    "default": "us-east-2",
-    "default_from_toml": {
-      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
-      "env": { "valueof": "testing_stage_name"},
-      "cmd_names": "pipeline_bootstrap",
-      "section": "parameters",
-      "key": "region"
+    "default": {
+      "keyPath": [
+          { "valueof": "testing_stage_name"},
+          "region"
+      ]
     }
   }, {
     "key": "prod_stage_name",
@@ -90,55 +84,49 @@
     "key": "prod_pipeline_execution_role",
     "question": "What is the production pipeline execution role ARN?",
     "isRequired": true,
-    "default_from_toml": {
-      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
-      "env": { "valueof": "prod_stage_name"},
-      "cmd_names": "pipeline_bootstrap",
-      "section": "parameters",
-      "key": "pipeline_execution_role"
+    "default": {
+      "keyPath": [
+          { "valueof": "prod_stage_name"},
+          "pipeline_execution_role"
+      ]
     }
   }, {
     "key": "prod_cloudformation_execution_role",
     "question": "What is the production CloudFormation execution role ARN?",
     "isRequired": true,
-    "default_from_toml": {
-      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
-      "env": { "valueof": "prod_stage_name"},
-      "cmd_names": "pipeline_bootstrap",
-      "section": "parameters",
-      "key": "cloudformation_execution_role"
+    "default": {
+      "keyPath": [
+          { "valueof": "prod_stage_name"},
+          "cloudformation_execution_role"
+      ]
     }
   }, {
     "key": "prod_artifacts_bucket",
     "question": "What is the production S3 bucket name for artifacts?",
     "isRequired": true,
-    "default_from_toml": {
-      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
-      "env": { "valueof": "prod_stage_name"},
-      "cmd_names": "pipeline_bootstrap",
-      "section": "parameters",
-      "key": "artifacts_bucket"
+    "default": {
+      "keyPath": [
+          { "valueof": "prod_stage_name"},
+          "artifacts_bucket"
+      ]
     }
   }, {
     "key": "prod_ecr_repo",
     "question": "What is the production ECR repository URI?",
-    "default_from_toml": {
-      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
-      "env": { "valueof": "prod_stage_name"},
-      "cmd_names": "pipeline_bootstrap",
-      "section": "parameters",
-      "key": "ecr_repo"
+    "default": {
+      "keyPath": [
+          { "valueof": "prod_stage_name"},
+          "ecr_repo"
+      ]
     }
   }, {
     "key": "prod_region",
     "question": "What is the production AWS region?",
-    "default": "us-east-2",
-    "default_from_toml": {
-      "toml_file": ".aws-sam/pipeline/pipelineconfig.toml",
-      "env": { "valueof": "prod_stage_name"},
-      "cmd_names": "pipeline_bootstrap",
-      "section": "parameters",
-      "key": "region"
+    "default": {
+      "keyPath": [
+          { "valueof": "prod_stage_name"},
+          "region"
+      ]
     }
   }]
 }


### PR DESCRIPTION
*Issue #, if available:*
Allow `sam pipeline init` to pre-fill the default values of infrastructure resources' ARNs questions from pipelineconfig.toml file generated by `sam pipeline bootstrap`

*Description of changes:*
Modify Jenkins and GH-Actions pipeline templates to read the default values of infrastructure resources ARNs from pipelineconfig.toml file

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
