### PR TITLE
Load default values from bootstrapped infrastructure

### DIFF
--- a/GitHub-Actions/two-stage-pipeline-template/questions.json
+++ b/GitHub-Actions/two-stage-pipeline-template/questions.json
@@ -22,8 +22,7 @@
   }, {
     "key": "testing_stage_name",
     "question": "What is the testing stage name (as provided during the bootstrapping) ?",
-    "isRequired": true,
-    "default": "testing"
+    "isRequired": true
   }, {
     "key": "testing_stack_name",
     "question": "What is the testing stack name?",

--- a/GitHub-Actions/two-stage-pipeline-template/questions.json
+++ b/GitHub-Actions/two-stage-pipeline-template/questions.json
@@ -21,7 +21,7 @@
     "kind": "info"
   }, {
     "key": "testing_stage_name",
-    "question": "What is the testing stage name (as provided during the bootstrapping) ?",
+    "question": "What is the testing stage name (as provided during the bootstrapping)?",
     "isRequired": true
   }, {
     "key": "testing_stack_name",
@@ -78,7 +78,7 @@
     }
   }, {
     "key": "prod_stage_name",
-    "question": "What is the production stage name?",
+    "question": "What is the production stage name (as provided during the bootstrapping)?",
     "isRequired": true
   }, {
     "key": "prod_stack_name",

--- a/GitHub-Actions/two-stage-pipeline-template/questions.json
+++ b/GitHub-Actions/two-stage-pipeline-template/questions.json
@@ -16,28 +16,71 @@
     "question": "What is the template file path?",
     "default": "template.yaml"
   }, {
+    "key": "message_testing_stage_name",
+    "question": "We use the stage name to automatically retrieve the bootstrapped resources created when you ran `sam pipeline bootstrap`",
+    "kind": "info"
+  }, {
+    "key": "testing_stage_name",
+    "question": "What is the testing stage name (as provided during the bootstrapping) ?",
+    "isRequired": true,
+    "default": "testing"
+  }, {
     "key": "testing_stack_name",
     "question": "What is the testing stack name?",
-    "isRequired": true
+    "isRequired": true,
+    "default": "testing"
   }, {
     "key": "testing_pipeline_execution_role",
     "question": "What is the testing pipeline execution role ARN?",
-    "isRequired": true
+    "isRequired": true,
+    "default": {
+      "keyPath": [
+          { "valueof": "testing_stage_name"},
+          "pipeline_execution_role"
+      ]
+    }
   }, {
     "key": "testing_cloudformation_execution_role",
     "question": "What is the testing CloudFormation execution role ARN?",
-    "isRequired": true
+    "isRequired": true,
+    "default": {
+      "keyPath": [
+          { "valueof": "testing_stage_name"},
+          "cloudformation_execution_role"
+      ]
+    }
   }, {
     "key": "testing_artifacts_bucket",
     "question": "What is the testing S3 bucket name for artifacts?",
-    "isRequired": true
+    "isRequired": true,
+    "default": {
+      "keyPath": [
+          { "valueof": "testing_stage_name"},
+          "artifacts_bucket"
+      ]
+    }
   }, {
     "key": "testing_ecr_repo",
     "question": "What is the testing ECR repository URI?",
+    "default": {
+      "keyPath": [
+          { "valueof": "testing_stage_name"},
+          "ecr_repo"
+      ]
+    }
   }, {
     "key": "testing_region",
     "question": "What is the testing AWS region?",
-    "default": "us-east-2"
+    "default": {
+      "keyPath": [
+          { "valueof": "testing_stage_name"},
+          "region"
+      ]
+    }
+  }, {
+    "key": "prod_stage_name",
+    "question": "What is the production stage name?",
+    "isRequired": true
   }, {
     "key": "prod_stack_name",
     "question": "What is the production stack name?",
@@ -45,21 +88,50 @@
   }, {
     "key": "prod_pipeline_execution_role",
     "question": "What is the production pipeline execution role ARN?",
-    "isRequired": true
+    "isRequired": true,
+    "default": {
+      "keyPath": [
+          { "valueof": "prod_stage_name"},
+          "pipeline_execution_role"
+      ]
+    }
   }, {
     "key": "prod_cloudformation_execution_role",
     "question": "What is the production CloudFormation execution role ARN?",
-    "isRequired": true
+    "isRequired": true,
+    "default": {
+      "keyPath": [
+          { "valueof": "prod_stage_name"},
+          "cloudformation_execution_role"
+      ]
+    }
   }, {
     "key": "prod_artifacts_bucket",
     "question": "What is the production S3 bucket name for artifacts?",
-    "isRequired": true
+    "isRequired": true,
+    "default": {
+      "keyPath": [
+          { "valueof": "prod_stage_name"},
+          "artifacts_bucket"
+      ]
+    }
   }, {
     "key": "prod_ecr_repo",
     "question": "What is the production ECR repository URI?",
+    "default": {
+      "keyPath": [
+          { "valueof": "prod_stage_name"},
+          "ecr_repo"
+      ]
+    }
   }, {
     "key": "prod_region",
     "question": "What is the production AWS region?",
-    "default": "us-east-2"
+    "default": {
+      "keyPath": [
+          { "valueof": "prod_stage_name"},
+          "region"
+      ]
+    }
   }]
 }

--- a/GitHub-Actions/two-stage-pipeline-template/questions.json
+++ b/GitHub-Actions/two-stage-pipeline-template/questions.json
@@ -34,7 +34,7 @@
     "isRequired": true,
     "default": {
       "keyPath": [
-          { "valueof": "testing_stage_name"},
+          { "valueOf": "testing_stage_name"},
           "pipeline_execution_role"
       ]
     }
@@ -44,7 +44,7 @@
     "isRequired": true,
     "default": {
       "keyPath": [
-          { "valueof": "testing_stage_name"},
+          { "valueOf": "testing_stage_name"},
           "cloudformation_execution_role"
       ]
     }
@@ -54,7 +54,7 @@
     "isRequired": true,
     "default": {
       "keyPath": [
-          { "valueof": "testing_stage_name"},
+          { "valueOf": "testing_stage_name"},
           "artifacts_bucket"
       ]
     }
@@ -63,7 +63,7 @@
     "question": "What is the testing ECR repository URI?",
     "default": {
       "keyPath": [
-          { "valueof": "testing_stage_name"},
+          { "valueOf": "testing_stage_name"},
           "ecr_repo"
       ]
     }
@@ -72,7 +72,7 @@
     "question": "What is the testing AWS region?",
     "default": {
       "keyPath": [
-          { "valueof": "testing_stage_name"},
+          { "valueOf": "testing_stage_name"},
           "region"
       ]
     }
@@ -90,7 +90,7 @@
     "isRequired": true,
     "default": {
       "keyPath": [
-          { "valueof": "prod_stage_name"},
+          { "valueOf": "prod_stage_name"},
           "pipeline_execution_role"
       ]
     }
@@ -100,7 +100,7 @@
     "isRequired": true,
     "default": {
       "keyPath": [
-          { "valueof": "prod_stage_name"},
+          { "valueOf": "prod_stage_name"},
           "cloudformation_execution_role"
       ]
     }
@@ -110,7 +110,7 @@
     "isRequired": true,
     "default": {
       "keyPath": [
-          { "valueof": "prod_stage_name"},
+          { "valueOf": "prod_stage_name"},
           "artifacts_bucket"
       ]
     }
@@ -119,7 +119,7 @@
     "question": "What is the production ECR repository URI?",
     "default": {
       "keyPath": [
-          { "valueof": "prod_stage_name"},
+          { "valueOf": "prod_stage_name"},
           "ecr_repo"
       ]
     }
@@ -128,7 +128,7 @@
     "question": "What is the production AWS region?",
     "default": {
       "keyPath": [
-          { "valueof": "prod_stage_name"},
+          { "valueOf": "prod_stage_name"},
           "region"
       ]
     }

--- a/Gitlab/two-stage-pipeline-template/questions.json
+++ b/Gitlab/two-stage-pipeline-template/questions.json
@@ -25,7 +25,7 @@
     "isRequired": true,
     "default": {
       "keyPath": [
-          { "valueof": "testing_stage_name"},
+          { "valueOf": "testing_stage_name"},
           "pipeline_execution_role"
       ]
     }
@@ -35,7 +35,7 @@
     "isRequired": true,
     "default": {
       "keyPath": [
-          { "valueof": "testing_stage_name"},
+          { "valueOf": "testing_stage_name"},
           "cloudformation_execution_role"
       ]
     }
@@ -45,7 +45,7 @@
     "isRequired": true,
     "default": {
       "keyPath": [
-          { "valueof": "testing_stage_name"},
+          { "valueOf": "testing_stage_name"},
           "artifacts_bucket"
       ]
     }
@@ -54,7 +54,7 @@
     "question": "What is the testing ECR repository URI?",
     "default": {
       "keyPath": [
-          { "valueof": "testing_stage_name"},
+          { "valueOf": "testing_stage_name"},
           "ecr_repo"
       ]
     }
@@ -63,7 +63,7 @@
     "question": "What is the testing AWS region?",
     "default": {
       "keyPath": [
-          { "valueof": "testing_stage_name"},
+          { "valueOf": "testing_stage_name"},
           "region"
       ]
     }
@@ -81,7 +81,7 @@
     "isRequired": true,
     "default": {
       "keyPath": [
-          { "valueof": "prod_stage_name"},
+          { "valueOf": "prod_stage_name"},
           "pipeline_execution_role"
       ]
     }
@@ -91,7 +91,7 @@
     "isRequired": true,
     "default": {
       "keyPath": [
-          { "valueof": "prod_stage_name"},
+          { "valueOf": "prod_stage_name"},
           "cloudformation_execution_role"
       ]
     }
@@ -101,7 +101,7 @@
     "isRequired": true,
     "default": {
       "keyPath": [
-          { "valueof": "prod_stage_name"},
+          { "valueOf": "prod_stage_name"},
           "artifacts_bucket"
       ]
     }
@@ -110,7 +110,7 @@
     "question": "What is the production ECR repository URI?",
     "default": {
       "keyPath": [
-          { "valueof": "prod_stage_name"},
+          { "valueOf": "prod_stage_name"},
           "ecr_repo"
       ]
     }
@@ -119,7 +119,7 @@
     "question": "What is the production AWS region?",
     "default": {
       "keyPath": [
-          { "valueof": "prod_stage_name"},
+          { "valueOf": "prod_stage_name"},
           "region"
       ]
     }

--- a/Gitlab/two-stage-pipeline-template/questions.json
+++ b/Gitlab/two-stage-pipeline-template/questions.json
@@ -8,28 +8,69 @@
     "question": "What is the template file path?",
     "default": "template.yaml"
   }, {
+    "key": "message_testing_stage_name",
+    "question": "We use the stage name to automatically retrieve the bootstrapped resources created when you ran `sam pipeline bootstrap`",
+    "kind": "info"
+  }, {
+    "key": "testing_stage_name",
+    "question": "What is the testing stage name (as provided during the bootstrapping) ?",
+    "isRequired": true
+  }, {
     "key": "testing_stack_name",
     "question": "What is the testing stack name?",
     "isRequired": true
   }, {
     "key": "testing_pipeline_execution_role",
     "question": "What is the testing pipeline execution role ARN?",
-    "isRequired": true
+    "isRequired": true,
+    "default": {
+      "keyPath": [
+          { "valueof": "testing_stage_name"},
+          "pipeline_execution_role"
+      ]
+    }
   }, {
     "key": "testing_cloudformation_execution_role",
     "question": "What is the testing CloudFormation execution role ARN?",
-    "isRequired": true
+    "isRequired": true,
+    "default": {
+      "keyPath": [
+          { "valueof": "testing_stage_name"},
+          "cloudformation_execution_role"
+      ]
+    }
   }, {
     "key": "testing_artifacts_bucket",
     "question": "What is the testing S3 bucket name for artifacts?",
-    "isRequired": true
+    "isRequired": true,
+    "default": {
+      "keyPath": [
+          { "valueof": "testing_stage_name"},
+          "artifacts_bucket"
+      ]
+    }
   }, {
     "key": "testing_ecr_repo",
     "question": "What is the testing ECR repository URI?",
+    "default": {
+      "keyPath": [
+          { "valueof": "testing_stage_name"},
+          "ecr_repo"
+      ]
+    }
   }, {
     "key": "testing_region",
     "question": "What is the testing AWS region?",
-    "default": "us-east-2"
+    "default": {
+      "keyPath": [
+          { "valueof": "testing_stage_name"},
+          "region"
+      ]
+    }
+  }, {
+    "key": "prod_stage_name",
+    "question": "What is the production stage name?",
+    "isRequired": true
   }, {
     "key": "prod_stack_name",
     "question": "What is the production stack name?",
@@ -37,21 +78,50 @@
   }, {
     "key": "prod_pipeline_execution_role",
     "question": "What is the production pipeline execution role ARN?",
-    "isRequired": true
+    "isRequired": true,
+    "default": {
+      "keyPath": [
+          { "valueof": "prod_stage_name"},
+          "pipeline_execution_role"
+      ]
+    }
   }, {
     "key": "prod_cloudformation_execution_role",
     "question": "What is the production CloudFormation execution role ARN?",
-    "isRequired": true
+    "isRequired": true,
+    "default": {
+      "keyPath": [
+          { "valueof": "prod_stage_name"},
+          "cloudformation_execution_role"
+      ]
+    }
   }, {
     "key": "prod_artifacts_bucket",
     "question": "What is the production S3 bucket name for artifacts?",
-    "isRequired": true
+    "isRequired": true,
+    "default": {
+      "keyPath": [
+          { "valueof": "prod_stage_name"},
+          "artifacts_bucket"
+      ]
+    }
   }, {
     "key": "prod_ecr_repo",
     "question": "What is the production ECR repository URI?",
+    "default": {
+      "keyPath": [
+          { "valueof": "prod_stage_name"},
+          "ecr_repo"
+      ]
+    }
   }, {
     "key": "prod_region",
     "question": "What is the production AWS region?",
-    "default": "us-east-2"
+    "default": {
+      "keyPath": [
+          { "valueof": "prod_stage_name"},
+          "region"
+      ]
+    }
   }]
 }

--- a/Gitlab/two-stage-pipeline-template/questions.json
+++ b/Gitlab/two-stage-pipeline-template/questions.json
@@ -13,7 +13,7 @@
     "kind": "info"
   }, {
     "key": "testing_stage_name",
-    "question": "What is the testing stage name (as provided during the bootstrapping) ?",
+    "question": "What is the testing stage name (as provided during the bootstrapping)?",
     "isRequired": true
   }, {
     "key": "testing_stack_name",
@@ -69,7 +69,7 @@
     }
   }, {
     "key": "prod_stage_name",
-    "question": "What is the production stage name?",
+    "question": "What is the production stage name (as provided during the bootstrapping)?",
     "isRequired": true
   }, {
     "key": "prod_stack_name",

--- a/Jenkins/two-stage-pipeline-template/questions.json
+++ b/Jenkins/two-stage-pipeline-template/questions.json
@@ -29,7 +29,7 @@
     "isRequired": true,
     "default": {
       "keyPath": [
-          { "valueof": "testing_stage_name"},
+          { "valueOf": "testing_stage_name"},
           "pipeline_execution_role"
       ]
     }
@@ -39,7 +39,7 @@
     "isRequired": true,
     "default": {
       "keyPath": [
-          { "valueof": "testing_stage_name"},
+          { "valueOf": "testing_stage_name"},
           "cloudformation_execution_role"
       ]
     }
@@ -49,7 +49,7 @@
     "isRequired": true,
     "default": {
       "keyPath": [
-          { "valueof": "testing_stage_name"},
+          { "valueOf": "testing_stage_name"},
           "artifacts_bucket"
       ]
     }
@@ -58,7 +58,7 @@
     "question": "What is the testing ECR repository URI?",
     "default": {
       "keyPath": [
-          { "valueof": "testing_stage_name"},
+          { "valueOf": "testing_stage_name"},
           "ecr_repo"
       ]
     }
@@ -67,7 +67,7 @@
     "question": "What is the testing AWS region?",
     "default": {
       "keyPath": [
-          { "valueof": "testing_stage_name"},
+          { "valueOf": "testing_stage_name"},
           "region"
       ]
     }
@@ -85,7 +85,7 @@
     "isRequired": true,
     "default": {
       "keyPath": [
-          { "valueof": "prod_stage_name"},
+          { "valueOf": "prod_stage_name"},
           "pipeline_execution_role"
       ]
     }
@@ -95,7 +95,7 @@
     "isRequired": true,
     "default": {
       "keyPath": [
-          { "valueof": "prod_stage_name"},
+          { "valueOf": "prod_stage_name"},
           "cloudformation_execution_role"
       ]
     }
@@ -105,7 +105,7 @@
     "isRequired": true,
     "default": {
       "keyPath": [
-          { "valueof": "prod_stage_name"},
+          { "valueOf": "prod_stage_name"},
           "artifacts_bucket"
       ]
     }
@@ -114,7 +114,7 @@
     "question": "What is the production ECR repository URI?",
     "default": {
       "keyPath": [
-          { "valueof": "prod_stage_name"},
+          { "valueOf": "prod_stage_name"},
           "ecr_repo"
       ]
     }
@@ -123,7 +123,7 @@
     "question": "What is the production AWS region?",
     "default": {
       "keyPath": [
-          { "valueof": "prod_stage_name"},
+          { "valueOf": "prod_stage_name"},
           "region"
       ]
     }

--- a/Jenkins/two-stage-pipeline-template/questions.json
+++ b/Jenkins/two-stage-pipeline-template/questions.json
@@ -17,7 +17,7 @@
     "kind": "info"
   }, {
     "key": "testing_stage_name",
-    "question": "What is the testing stage name (as provided during the bootstrapping) ?",
+    "question": "What is the testing stage name (as provided during the bootstrapping)?",
     "isRequired": true
   }, {
     "key": "testing_stack_name",
@@ -73,7 +73,7 @@
     }
   }, {
     "key": "prod_stage_name",
-    "question": "What is the production stage name?",
+    "question": "What is the production stage name (as provided during the bootstrapping)?",
     "isRequired": true
   }, {
     "key": "prod_stack_name",

--- a/Jenkins/two-stage-pipeline-template/questions.json
+++ b/Jenkins/two-stage-pipeline-template/questions.json
@@ -12,28 +12,70 @@
     "question": "What is the template file path?",
     "default": "template.yaml"
   }, {
+    "key": "message_testing_stage_name",
+    "question": "We use the stage name to automatically retrieve the bootstrapped resources created when you ran `sam pipeline bootstrap`",
+    "kind": "info"
+  }, {
+    "key": "testing_stage_name",
+    "question": "What is the testing stage name (as provided during the bootstrapping) ?",
+    "isRequired": true,
+    "default": "testing"
+  }, {
     "key": "testing_stack_name",
     "question": "What is the testing stack name?",
     "isRequired": true
   }, {
     "key": "testing_pipeline_execution_role",
     "question": "What is the testing pipeline execution role ARN?",
-    "isRequired": true
+    "isRequired": true,
+    "default": {
+      "keyPath": [
+          { "valueof": "testing_stage_name"},
+          "pipeline_execution_role"
+      ]
+    }
   }, {
     "key": "testing_cloudformation_execution_role",
     "question": "What is the testing CloudFormation execution role ARN?",
-    "isRequired": true
+    "isRequired": true,
+    "default": {
+      "keyPath": [
+          { "valueof": "testing_stage_name"},
+          "cloudformation_execution_role"
+      ]
+    }
   }, {
     "key": "testing_artifacts_bucket",
     "question": "What is the testing S3 bucket name for artifacts?",
-    "isRequired": true
+    "isRequired": true,
+    "default": {
+      "keyPath": [
+          { "valueof": "testing_stage_name"},
+          "artifacts_bucket"
+      ]
+    }
   }, {
     "key": "testing_ecr_repo",
     "question": "What is the testing ECR repository URI?",
+    "default": {
+      "keyPath": [
+          { "valueof": "testing_stage_name"},
+          "ecr_repo"
+      ]
+    }
   }, {
     "key": "testing_region",
     "question": "What is the testing AWS region?",
-    "default": "us-east-2"
+    "default": {
+      "keyPath": [
+          { "valueof": "testing_stage_name"},
+          "region"
+      ]
+    }
+  }, {
+    "key": "prod_stage_name",
+    "question": "What is the production stage name?",
+    "isRequired": true
   }, {
     "key": "prod_stack_name",
     "question": "What is the production stack name?",
@@ -41,21 +83,50 @@
   }, {
     "key": "prod_pipeline_execution_role",
     "question": "What is the production pipeline execution role ARN?",
-    "isRequired": true
+    "isRequired": true,
+    "default": {
+      "keyPath": [
+          { "valueof": "prod_stage_name"},
+          "pipeline_execution_role"
+      ]
+    }
   }, {
     "key": "prod_cloudformation_execution_role",
     "question": "What is the production CloudFormation execution role ARN?",
-    "isRequired": true
+    "isRequired": true,
+    "default": {
+      "keyPath": [
+          { "valueof": "prod_stage_name"},
+          "cloudformation_execution_role"
+      ]
+    }
   }, {
     "key": "prod_artifacts_bucket",
     "question": "What is the production S3 bucket name for artifacts?",
-    "isRequired": true
+    "isRequired": true,
+    "default": {
+      "keyPath": [
+          { "valueof": "prod_stage_name"},
+          "artifacts_bucket"
+      ]
+    }
   }, {
     "key": "prod_ecr_repo",
     "question": "What is the production ECR repository URI?",
+    "default": {
+      "keyPath": [
+          { "valueof": "prod_stage_name"},
+          "ecr_repo"
+      ]
+    }
   }, {
     "key": "prod_region",
     "question": "What is the production AWS region?",
-    "default": "us-east-2"
+    "default": {
+      "keyPath": [
+          { "valueof": "prod_stage_name"},
+          "region"
+      ]
+    }
   }]
 }

--- a/Jenkins/two-stage-pipeline-template/questions.json
+++ b/Jenkins/two-stage-pipeline-template/questions.json
@@ -18,8 +18,7 @@
   }, {
     "key": "testing_stage_name",
     "question": "What is the testing stage name (as provided during the bootstrapping) ?",
-    "isRequired": true,
-    "default": "testing"
+    "isRequired": true
   }, {
     "key": "testing_stack_name",
     "question": "What is the testing stack name?",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
instead of having the user entering the ARNs of the required pipeline infrastructure resources, load it from default toml file

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
