### PR TITLE
fix: Post hooks cannot delete outDir on Windows

### DIFF
--- a/GitHub-Actions/two-stage-pipeline-template/hooks/post_gen_project.py
+++ b/GitHub-Actions/two-stage-pipeline-template/hooks/post_gen_project.py
@@ -20,4 +20,6 @@ if destination_file.exists():
 os.rename(workflow_file_name, destination_file)
 
 # There is only one file in output_dir, remove it
-shutil.rmtree(Path.cwd().resolve())
+# on Windows, cwd cannot be deleted. Change the cwd to project_root first.
+os.chdir(project_root_dir)
+shutil.rmtree(output_dir)

--- a/Gitlab/two-stage-pipeline-template/hooks/post_gen_project.py
+++ b/Gitlab/two-stage-pipeline-template/hooks/post_gen_project.py
@@ -21,4 +21,6 @@ if os.path.exists(assume_role_file_path):
 os.rename(gitlab_file, os.path.join(project_root_dir, gitlab_file))
 os.rename(assume_role_file, os.path.join(project_root_dir, assume_role_file))
 
-shutil.rmtree(os.path.join(project_root_dir, output_dir))
+# on Windows, cwd cannot be deleted. Change the cwd to project_root first.
+os.chdir(project_root_dir)
+shutil.rmtree(output_dir)

--- a/Jenkins/two-stage-pipeline-template/hooks/post_gen_project.py
+++ b/Jenkins/two-stage-pipeline-template/hooks/post_gen_project.py
@@ -15,4 +15,6 @@ if os.path.exists(destination_file_path):
 os.rename(jenkinsfile, os.path.join(project_root_dir, jenkinsfile))
 
 # There is only one file in output_dir, remove it
-shutil.rmtree(os.path.join(project_root_dir, output_dir))
+# on Windows, cwd cannot be deleted. Change the cwd to project_root first.
+os.chdir(project_root_dir)
+shutil.rmtree(output_dir)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
