### PR TITLE
Change GH Action retention date to 90 days

### DIFF
--- a/GitHub-Actions/two-stage-pipeline-template/{{cookiecutter.outputDir}}/.github/workflows/pipeline.yaml
+++ b/GitHub-Actions/two-stage-pipeline-template/{{cookiecutter.outputDir}}/.github/workflows/pipeline.yaml
@@ -144,7 +144,6 @@ jobs:
         with:
           name: packaged-prod.yaml
           path: packaged-prod.yaml
-          retention-days: 90
     
   deploy-testing:
     if: github.ref == 'refs/heads/{{ cookiecutter.main_git_branch }}'

--- a/GitHub-Actions/two-stage-pipeline-template/{{cookiecutter.outputDir}}/.github/workflows/pipeline.yaml
+++ b/GitHub-Actions/two-stage-pipeline-template/{{cookiecutter.outputDir}}/.github/workflows/pipeline.yaml
@@ -118,7 +118,6 @@ jobs:
         with:
           name: packaged-testing.yaml
           path: packaged-testing.yaml
-          retention-days: 90
           
       - name: Assume the prod pipeline user role
         uses: aws-actions/configure-aws-credentials@v1

--- a/GitHub-Actions/two-stage-pipeline-template/{{cookiecutter.outputDir}}/.github/workflows/pipeline.yaml
+++ b/GitHub-Actions/two-stage-pipeline-template/{{cookiecutter.outputDir}}/.github/workflows/pipeline.yaml
@@ -118,7 +118,7 @@ jobs:
         with:
           name: packaged-testing.yaml
           path: packaged-testing.yaml
-          retention-days: 365
+          retention-days: 90
           
       - name: Assume the prod pipeline user role
         uses: aws-actions/configure-aws-credentials@v1
@@ -145,7 +145,7 @@ jobs:
         with:
           name: packaged-prod.yaml
           path: packaged-prod.yaml
-          retention-days: 365
+          retention-days: 90
     
   deploy-testing:
     if: github.ref == 'refs/heads/{{ cookiecutter.main_git_branch }}'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Because GH Action has 90 days limit for free users.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
