### PR TITLE
Improve select stage name process and unify stage descriptions

### DIFF
--- a/GitHub-Actions/two-stage-pipeline-template/questions.json
+++ b/GitHub-Actions/two-stage-pipeline-template/questions.json
@@ -31,7 +31,7 @@
     "kind": "info"
   }, {
     "key": "testing_stage_name",
-    "question": "What is the testing stage name (as provided during the bootstrapping)?",
+    "question": "What is the testing stage name (as provided during the bootstrapping)?\nSelect an index or enter the stage name:",
     "isRequired": true
   }, {
     "key": "testing_stack_name",
@@ -103,7 +103,7 @@
     "kind": "info"
   }, {
     "key": "prod_stage_name",
-    "question": "What is the production stage name (as provided during the bootstrapping)?",
+    "question": "What is the production stage name (as provided during the bootstrapping)?\nSelect an index or enter the stage name:",
     "isRequired": true
   }, {
     "key": "prod_stack_name",

--- a/GitHub-Actions/two-stage-pipeline-template/questions.json
+++ b/GitHub-Actions/two-stage-pipeline-template/questions.json
@@ -31,15 +31,15 @@
     "kind": "info"
   }, {
     "key": "testing_stage_name",
-    "question": "What is the testing stage name (as provided during the bootstrapping)?\nSelect an index or enter the stage name:",
+    "question": "What is the name of stage 1 (as provided during the bootstrapping)?\nSelect an index or enter the stage name:",
     "isRequired": true
   }, {
     "key": "testing_stack_name",
-    "question": "What is the testing stack name?",
+    "question": "What is the sam application stack name for stage 1?",
     "isRequired": true
   }, {
     "key": "testing_pipeline_execution_role",
-    "question": "What is the testing pipeline execution role ARN?",
+    "question": "What is the pipeline execution role ARN for stage 1?",
     "isRequired": true,
     "allowAutofill": true,
     "default": {
@@ -50,7 +50,7 @@
     }
   }, {
     "key": "testing_cloudformation_execution_role",
-    "question": "What is the testing CloudFormation execution role ARN?",
+    "question": "What is the CloudFormation execution role ARN for stage 1?",
     "isRequired": true,
     "allowAutofill": true,
     "default": {
@@ -61,7 +61,7 @@
     }
   }, {
     "key": "testing_artifacts_bucket",
-    "question": "What is the testing S3 bucket name for artifacts?",
+    "question": "What is the S3 bucket name for artifacts for stage 1?",
     "isRequired": true,
     "allowAutofill": true,
     "default": {
@@ -72,7 +72,7 @@
     }
   }, {
     "key": "testing_image_repository",
-    "question": "What is the testing ECR repository URI?",
+    "question": "What is the ECR repository URI for stage 1?",
     "allowAutofill": true,
     "default": {
       "keyPath": [
@@ -82,7 +82,7 @@
     }
   }, {
     "key": "testing_region",
-    "question": "What is the testing AWS region?",
+    "question": "What is the AWS region for stage 1?",
     "isRequired": true,
     "allowAutofill": true,
     "default": {
@@ -103,15 +103,15 @@
     "kind": "info"
   }, {
     "key": "prod_stage_name",
-    "question": "What is the production stage name (as provided during the bootstrapping)?\nSelect an index or enter the stage name:",
+    "question": "What is the name of stage 2 (as provided during the bootstrapping)?\nSelect an index or enter the stage name:",
     "isRequired": true
   }, {
     "key": "prod_stack_name",
-    "question": "What is the production stack name?",
+    "question": "What is the sam application stack name for stage 2?",
     "isRequired": true
   }, {
     "key": "prod_pipeline_execution_role",
-    "question": "What is the production pipeline execution role ARN?",
+    "question": "What is the pipeline execution role ARN for stage 2?",
     "isRequired": true,
     "allowAutofill": true,
     "default": {
@@ -122,7 +122,7 @@
     }
   }, {
     "key": "prod_cloudformation_execution_role",
-    "question": "What is the production CloudFormation execution role ARN?",
+    "question": "What is the CloudFormation execution role ARN for stage 2?",
     "isRequired": true,
     "allowAutofill": true,
     "default": {
@@ -133,7 +133,7 @@
     }
   }, {
     "key": "prod_artifacts_bucket",
-    "question": "What is the production S3 bucket name for artifacts?",
+    "question": "What is the S3 bucket name for artifacts for stage 2?",
     "isRequired": true,
     "allowAutofill": true,
     "default": {
@@ -144,7 +144,7 @@
     }
   }, {
     "key": "prod_image_repository",
-    "question": "What is the production ECR repository URI?",
+    "question": "What is the ECR repository URI for stage 2?",
     "allowAutofill": true,
     "default": {
       "keyPath": [
@@ -154,7 +154,7 @@
     }
   }, {
     "key": "prod_region",
-    "question": "What is the production AWS region?",
+    "question": "What is the AWS region for stage 2?",
     "isRequired": true,
     "allowAutofill": true,
     "default": {

--- a/Gitlab/two-stage-pipeline-template/questions.json
+++ b/Gitlab/two-stage-pipeline-template/questions.json
@@ -23,7 +23,7 @@
     "kind": "info"
   }, {
     "key": "testing_stage_name",
-    "question": "What is the testing stage name (as provided during the bootstrapping)?",
+    "question": "What is the testing stage name (as provided during the bootstrapping)?\nSelect an index or enter the stage name:",
     "isRequired": true
   }, {
     "key": "testing_stack_name",
@@ -95,7 +95,7 @@
     "kind": "info"
   }, {
     "key": "prod_stage_name",
-    "question": "What is the production stage name (as provided during the bootstrapping)?",
+    "question": "What is the production stage name (as provided during the bootstrapping)?\nSelect an index or enter the stage name:",
     "isRequired": true
   }, {
     "key": "prod_stack_name",

--- a/Gitlab/two-stage-pipeline-template/questions.json
+++ b/Gitlab/two-stage-pipeline-template/questions.json
@@ -23,15 +23,15 @@
     "kind": "info"
   }, {
     "key": "testing_stage_name",
-    "question": "What is the testing stage name (as provided during the bootstrapping)?\nSelect an index or enter the stage name:",
+    "question": "What is the name of stage 1 (as provided during the bootstrapping)?\nSelect an index or enter the stage name:",
     "isRequired": true
   }, {
     "key": "testing_stack_name",
-    "question": "What is the testing stack name?",
+    "question": "What is the sam application stack name for stage 1?",
     "isRequired": true
   }, {
     "key": "testing_pipeline_execution_role",
-    "question": "What is the testing pipeline execution role ARN?",
+    "question": "What is the pipeline execution role ARN for stage 1?",
     "isRequired": true,
     "allowAutofill": true,
     "default": {
@@ -42,7 +42,7 @@
     }
   }, {
     "key": "testing_cloudformation_execution_role",
-    "question": "What is the testing CloudFormation execution role ARN?",
+    "question": "What is the CloudFormation execution role ARN for stage 1?",
     "isRequired": true,
     "allowAutofill": true,
     "default": {
@@ -53,7 +53,7 @@
     }
   }, {
     "key": "testing_artifacts_bucket",
-    "question": "What is the testing S3 bucket name for artifacts?",
+    "question": "What is the S3 bucket name for artifacts for stage 1?",
     "isRequired": true,
     "allowAutofill": true,
     "default": {
@@ -64,7 +64,7 @@
     }
   }, {
     "key": "testing_image_repository",
-    "question": "What is the testing ECR repository URI?",
+    "question": "What is the ECR repository URI for stage 1?",
     "allowAutofill": true,
     "default": {
       "keyPath": [
@@ -74,7 +74,7 @@
     }
   }, {
     "key": "testing_region",
-    "question": "What is the testing AWS region?",
+    "question": "What is the AWS region for stage 1?",
     "isRequired": true,
     "allowAutofill": true,
     "default": {
@@ -95,15 +95,15 @@
     "kind": "info"
   }, {
     "key": "prod_stage_name",
-    "question": "What is the production stage name (as provided during the bootstrapping)?\nSelect an index or enter the stage name:",
+    "question": "What is the name of stage 1 (as provided during the bootstrapping)?\nSelect an index or enter the stage name:",
     "isRequired": true
   }, {
     "key": "prod_stack_name",
-    "question": "What is the production stack name?",
+    "question": "What is the sam application stack name for stage 2?",
     "isRequired": true
   }, {
     "key": "prod_pipeline_execution_role",
-    "question": "What is the production pipeline execution role ARN?",
+    "question": "What is the pipeline execution role ARN for stage 2?",
     "isRequired": true,
     "allowAutofill": true,
     "default": {
@@ -114,7 +114,7 @@
     }
   }, {
     "key": "prod_cloudformation_execution_role",
-    "question": "What is the production CloudFormation execution role ARN?",
+    "question": "What is the CloudFormation execution role ARN for stage 2?",
     "isRequired": true,
     "allowAutofill": true,
     "default": {
@@ -125,7 +125,7 @@
     }
   }, {
     "key": "prod_artifacts_bucket",
-    "question": "What is the production S3 bucket name for artifacts?",
+    "question": "What is the S3 bucket name for artifacts for stage 2?",
     "isRequired": true,
     "allowAutofill": true,
     "default": {
@@ -136,7 +136,7 @@
     }
   }, {
     "key": "prod_image_repository",
-    "question": "What is the production ECR repository URI?",
+    "question": "What is the ECR repository URI for stage 2?",
     "allowAutofill": true,
     "default": {
       "keyPath": [
@@ -146,7 +146,7 @@
     }
   }, {
     "key": "prod_region",
-    "question": "What is the production AWS region?",
+    "question": "What is the AWS region for stage 2?",
     "isRequired": true,
     "allowAutofill": true,
     "default": {

--- a/Jenkins/two-stage-pipeline-template/questions.json
+++ b/Jenkins/two-stage-pipeline-template/questions.json
@@ -27,7 +27,7 @@
     "kind": "info"
   }, {
     "key": "testing_stage_name",
-    "question": "What is the testing stage name (as provided during the bootstrapping)?",
+    "question": "What is the testing stage name (as provided during the bootstrapping)?\nSelect an index or enter the stage name:",
     "isRequired": true
   }, {
     "key": "testing_stack_name",
@@ -99,7 +99,7 @@
     "kind": "info"
   }, {
     "key": "prod_stage_name",
-    "question": "What is the production stage name (as provided during the bootstrapping)?",
+    "question": "What is the production stage name (as provided during the bootstrapping)?\nSelect an index or enter the stage name:",
     "isRequired": true
   }, {
     "key": "prod_stack_name",

--- a/Jenkins/two-stage-pipeline-template/questions.json
+++ b/Jenkins/two-stage-pipeline-template/questions.json
@@ -27,15 +27,15 @@
     "kind": "info"
   }, {
     "key": "testing_stage_name",
-    "question": "What is the testing stage name (as provided during the bootstrapping)?\nSelect an index or enter the stage name:",
+    "question": "What is the name of stage 1 (as provided during the bootstrapping)?\nSelect an index or enter the stage name:",
     "isRequired": true
   }, {
     "key": "testing_stack_name",
-    "question": "What is the testing stack name?",
+    "question": "What is the sam application stack name for stage 1?",
     "isRequired": true
   }, {
     "key": "testing_pipeline_execution_role",
-    "question": "What is the testing pipeline execution role ARN?",
+    "question": "What is the pipeline execution role ARN for stage 1?",
     "isRequired": true,
     "allowAutofill": true,
     "default": {
@@ -46,7 +46,7 @@
     }
   }, {
     "key": "testing_cloudformation_execution_role",
-    "question": "What is the testing CloudFormation execution role ARN?",
+    "question": "What is the CloudFormation execution role ARN for stage 1?",
     "isRequired": true,
     "allowAutofill": true,
     "default": {
@@ -57,7 +57,7 @@
     }
   }, {
     "key": "testing_artifacts_bucket",
-    "question": "What is the testing S3 bucket name for artifacts?",
+    "question": "What is the S3 bucket name for artifacts for stage 1?",
     "isRequired": true,
     "allowAutofill": true,
     "default": {
@@ -68,7 +68,7 @@
     }
   }, {
     "key": "testing_image_repository",
-    "question": "What is the testing ECR repository URI?",
+    "question": "What is the ECR repository URI for stage 1?",
     "allowAutofill": true,
     "default": {
       "keyPath": [
@@ -78,7 +78,7 @@
     }
   }, {
     "key": "testing_region",
-    "question": "What is the testing AWS region?",
+    "question": "What is the AWS region for stage 1?",
     "isRequired": true,
     "allowAutofill": true,
     "default": {
@@ -99,15 +99,15 @@
     "kind": "info"
   }, {
     "key": "prod_stage_name",
-    "question": "What is the production stage name (as provided during the bootstrapping)?\nSelect an index or enter the stage name:",
+    "question": "What is the name of stage 1 (as provided during the bootstrapping)?\nSelect an index or enter the stage name:",
     "isRequired": true
   }, {
     "key": "prod_stack_name",
-    "question": "What is the production stack name?",
+    "question": "What is the sam application stack name for stage 2?",
     "isRequired": true
   }, {
     "key": "prod_pipeline_execution_role",
-    "question": "What is the production pipeline execution role ARN?",
+    "question": "What is the pipeline execution role ARN for stage 2?",
     "isRequired": true,
     "allowAutofill": true,
     "default": {
@@ -118,7 +118,7 @@
     }
   }, {
     "key": "prod_cloudformation_execution_role",
-    "question": "What is the production CloudFormation execution role ARN?",
+    "question": "What is the CloudFormation execution role ARN for stage 2?",
     "isRequired": true,
     "allowAutofill": true,
     "default": {
@@ -129,7 +129,7 @@
     }
   }, {
     "key": "prod_artifacts_bucket",
-    "question": "What is the production S3 bucket name for artifacts?",
+    "question": "What is the S3 bucket name for artifacts for stage 2?",
     "isRequired": true,
     "allowAutofill": true,
     "default": {
@@ -140,7 +140,7 @@
     }
   }, {
     "key": "prod_image_repository",
-    "question": "What is the production ECR repository URI?",
+    "question": "What is the ECR repository URI for stage 2?",
     "allowAutofill": true,
     "default": {
       "keyPath": [
@@ -150,7 +150,7 @@
     }
   }, {
     "key": "prod_region",
-    "question": "What is the production AWS region?",
+    "question": "What is the AWS region for stage 2?",
     "isRequired": true,
     "allowAutofill": true,
     "default": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

```
What is the template file path? [template.yaml]: 
We use the stage name to automatically retrieve the bootstrapped resources created when you ran `sam pipeline bootstrap`.

Here are the stage names detected in .aws-sam/pipeline/pipelineconfig.toml:
         1 - test
         2 - prod
What is the name of stage 1 (as provided during the bootstrapping)?
Select an index or enter the stage name: 1
What is the sam application stack name for stage 1?: stack-test
Stage 1 configured successfully, configuring stage 2.

Here are the stage names detected in .aws-sam/pipeline/pipelineconfig.toml:
         1 - test
         2 - prod
What is the name of stage 2 (as provided during the bootstrapping)?
Select an index or enter the stage name: prod
What is the sam application stack name for stage 2?:
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
