### PR TITLE
Add default stack name: "sam-app"

### DIFF
--- a/GitHub-Actions/two-stage-pipeline-template/questions.json
+++ b/GitHub-Actions/two-stage-pipeline-template/questions.json
@@ -36,7 +36,8 @@
   }, {
     "key": "testing_stack_name",
     "question": "What is the sam application stack name for stage 1?",
-    "isRequired": true
+    "isRequired": true,
+    "default": "sam-app"
   }, {
     "key": "testing_pipeline_execution_role",
     "question": "What is the pipeline execution role ARN for stage 1?",
@@ -108,7 +109,8 @@
   }, {
     "key": "prod_stack_name",
     "question": "What is the sam application stack name for stage 2?",
-    "isRequired": true
+    "isRequired": true,
+    "default": "sam-app"
   }, {
     "key": "prod_pipeline_execution_role",
     "question": "What is the pipeline execution role ARN for stage 2?",

--- a/Gitlab/two-stage-pipeline-template/questions.json
+++ b/Gitlab/two-stage-pipeline-template/questions.json
@@ -28,7 +28,8 @@
   }, {
     "key": "testing_stack_name",
     "question": "What is the sam application stack name for stage 1?",
-    "isRequired": true
+    "isRequired": true,
+    "default": "sam-app"
   }, {
     "key": "testing_pipeline_execution_role",
     "question": "What is the pipeline execution role ARN for stage 1?",
@@ -100,7 +101,8 @@
   }, {
     "key": "prod_stack_name",
     "question": "What is the sam application stack name for stage 2?",
-    "isRequired": true
+    "isRequired": true,
+    "default": "sam-app"
   }, {
     "key": "prod_pipeline_execution_role",
     "question": "What is the pipeline execution role ARN for stage 2?",

--- a/Jenkins/two-stage-pipeline-template/questions.json
+++ b/Jenkins/two-stage-pipeline-template/questions.json
@@ -32,7 +32,8 @@
   }, {
     "key": "testing_stack_name",
     "question": "What is the sam application stack name for stage 1?",
-    "isRequired": true
+    "isRequired": true,
+    "default": "sam-app"
   }, {
     "key": "testing_pipeline_execution_role",
     "question": "What is the pipeline execution role ARN for stage 1?",
@@ -104,7 +105,8 @@
   }, {
     "key": "prod_stack_name",
     "question": "What is the sam application stack name for stage 2?",
-    "isRequired": true
+    "isRequired": true,
+    "default": "sam-app"
   }, {
     "key": "prod_pipeline_execution_role",
     "question": "What is the pipeline execution role ARN for stage 2?",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

```
Here are the stage names detected in .aws-sam/pipeline/pipelineconfig.toml:
        1 - test
        2 - prod
What is the name of stage 1 (as provided during the bootstrapping)?
Select an index or enter the stage name: 1
What is the sam application stack name for stage 1? [sam-app]: 
Stage 1 configured successfully, configuring stage 2.
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
