### PR TITLE
Remove the extra ":" from stage name question

### DIFF
--- a/GitHub-Actions/two-stage-pipeline-template/questions.json
+++ b/GitHub-Actions/two-stage-pipeline-template/questions.json
@@ -31,7 +31,7 @@
     "kind": "info"
   }, {
     "key": "testing_stage_name",
-    "question": "What is the name of stage 1 (as provided during the bootstrapping)?\nSelect an index or enter the stage name:",
+    "question": "What is the name of stage 1 (as provided during the bootstrapping)?\nSelect an index or enter the stage name",
     "isRequired": true
   }, {
     "key": "testing_stack_name",
@@ -104,7 +104,7 @@
     "kind": "info"
   }, {
     "key": "prod_stage_name",
-    "question": "What is the name of stage 2 (as provided during the bootstrapping)?\nSelect an index or enter the stage name:",
+    "question": "What is the name of stage 2 (as provided during the bootstrapping)?\nSelect an index or enter the stage name",
     "isRequired": true
   }, {
     "key": "prod_stack_name",

--- a/Gitlab/two-stage-pipeline-template/questions.json
+++ b/Gitlab/two-stage-pipeline-template/questions.json
@@ -31,7 +31,7 @@
     "kind": "info"
   }, {
     "key": "testing_stage_name",
-    "question": "What is the name of stage 1 (as provided during the bootstrapping)?\nSelect an index or enter the stage name:",
+    "question": "What is the name of stage 1 (as provided during the bootstrapping)?\nSelect an index or enter the stage name",
     "isRequired": true
   }, {
     "key": "testing_stack_name",
@@ -104,7 +104,7 @@
     "kind": "info"
   }, {
     "key": "prod_stage_name",
-    "question": "What is the name of stage 1 (as provided during the bootstrapping)?\nSelect an index or enter the stage name:",
+    "question": "What is the name of stage 1 (as provided during the bootstrapping)?\nSelect an index or enter the stage name",
     "isRequired": true
   }, {
     "key": "prod_stack_name",

--- a/Jenkins/two-stage-pipeline-template/questions.json
+++ b/Jenkins/two-stage-pipeline-template/questions.json
@@ -27,7 +27,7 @@
     "kind": "info"
   }, {
     "key": "testing_stage_name",
-    "question": "What is the name of stage 1 (as provided during the bootstrapping)?\nSelect an index or enter the stage name:",
+    "question": "What is the name of stage 1 (as provided during the bootstrapping)?\nSelect an index or enter the stage name",
     "isRequired": true
   }, {
     "key": "testing_stack_name",
@@ -100,7 +100,7 @@
     "kind": "info"
   }, {
     "key": "prod_stage_name",
-    "question": "What is the name of stage 1 (as provided during the bootstrapping)?\nSelect an index or enter the stage name:",
+    "question": "What is the name of stage 1 (as provided during the bootstrapping)?\nSelect an index or enter the stage name",
     "isRequired": true
   }, {
     "key": "prod_stack_name",


### PR DESCRIPTION
*Issue #, if available:*


There is an extra `:` in the prompt

```
Here are the stage names detected in .aws-sam/pipeline/pipelineconfig.toml:
        1 - test
        2 - prod
What is the name of stage 1 (as provided during the bootstrapping)?
Select an index or enter the stage name::
```

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
