### PR TITLE
Add provider Bitbucket Pipelines

### DIFF
--- a/Bitbucket-Pipelines/two-stage-pipeline-template/cookiecutter.json
+++ b/Bitbucket-Pipelines/two-stage-pipeline-template/cookiecutter.json
@@ -1,0 +1,17 @@
+{
+  "outputDir": "aws-sam-pipeline",
+  "main_git_branch": "",
+  "sam_template": "",
+  "testing_stack_name": "",
+  "testing_pipeline_execution_role": "",
+  "testing_cloudformation_execution_role": "",
+  "testing_artifacts_bucket": "",
+  "testing_image_repository": "",
+  "testing_region": "",
+  "prod_stack_name": "",
+  "prod_pipeline_execution_role": "",
+  "prod_cloudformation_execution_role": "",
+  "prod_artifacts_bucket": "",
+  "prod_image_repository": "",
+  "prod_region": ""
+}

--- a/Bitbucket-Pipelines/two-stage-pipeline-template/metadata.json
+++ b/Bitbucket-Pipelines/two-stage-pipeline-template/metadata.json
@@ -1,0 +1,3 @@
+{
+  "number_of_stages": 2
+}

--- a/Bitbucket-Pipelines/two-stage-pipeline-template/questions.json
+++ b/Bitbucket-Pipelines/two-stage-pipeline-template/questions.json
@@ -1,0 +1,134 @@
+{
+  "questions": [{
+    "key": "intro",
+    "question": "\nThis template configures a pipeline that deploys a serverless application to a testing and a production stage.\n",
+    "kind": "info"
+  }, {
+    "key": "main_git_branch",
+    "question": "What is the git branch used for production deployments?",
+    "default": "main"
+  }, {
+    "key": "sam_template",
+    "question": "What is the template file path?",
+    "default": "template.yaml"
+  }, {
+    "key": "message_stage_name",
+    "question": "We use the stage name to automatically retrieve the bootstrapped resources created when you ran `sam pipeline bootstrap`.\n",
+    "kind": "info"
+  }, {
+    "key": "message_list_stage_names_testing",
+    "question": {
+      "keyPath": ["stage_names_message"]
+    },
+    "kind": "info"
+  }, {
+    "key": "testing_stage_name",
+    "question": "What is the name of stage 1 (as provided during the bootstrapping)?\nSelect an index or enter the stage name",
+    "isRequired": true
+  }, {
+    "key": "testing_stack_name",
+    "question": "What is the sam application stack name for stage 1?",
+    "isRequired": true,
+    "default": "sam-app"
+  }, {
+    "key": "testing_pipeline_execution_role",
+    "question": "What is the pipeline execution role ARN for stage 1?",
+    "isRequired": true,
+    "default": "$AWS_OIDC_ROLE_ARN"
+  }, {
+    "key": "testing_cloudformation_execution_role",
+    "question": "What is the CloudFormation execution role ARN for stage 1?",
+    "isRequired": false,
+    "allowAutofill": true,
+    "default": {
+      "keyPath": [
+          { "valueOf": "testing_stage_name"},
+          "cloudformation_execution_role"
+      ]
+    }
+  }, {
+    "key": "testing_artifacts_bucket",
+    "question": "What is the S3 bucket name for artifacts for stage 1?",
+    "isRequired": true,
+    "allowAutofill": true,
+    "default": {
+      "keyPath": [
+          { "valueOf": "testing_stage_name"},
+          "artifacts_bucket"
+      ]
+    }
+  }, {
+    "key": "testing_region",
+    "question": "What is the AWS region for stage 1?",
+    "isRequired": true,
+    "allowAutofill": true,
+    "default": {
+      "keyPath": [
+          { "valueOf": "testing_stage_name"},
+          "region"
+      ]
+    }
+  }, {
+    "key": "message_testing_stage_configured",
+    "question": "Stage 1 configured successfully, configuring stage 2.\n",
+    "kind": "info"
+  }, {
+    "key": "message_list_stage_names_prod",
+    "question": {
+      "keyPath": ["stage_names_message"]
+    },
+    "kind": "info"
+  }, {
+    "key": "prod_stage_name",
+    "question": "What is the name of stage 2 (as provided during the bootstrapping)?\nSelect an index or enter the stage name",
+    "isRequired": true
+  }, {
+    "key": "prod_stack_name",
+    "question": "What is the sam application stack name for stage 2?",
+    "isRequired": true,
+    "default": "sam-app"
+  }, {
+    "key": "prod_pipeline_execution_role",
+    "question": "What is the pipeline execution role ARN for stage 2?",
+    "isRequired": true,
+    "allowAutofill": true,
+    "default": {
+      "keyPath": [
+          { "valueOf": "prod_stage_name"},
+          "pipeline_execution_role"
+      ]
+    }
+  }, {
+    "key": "prod_cloudformation_execution_role",
+    "question": "What is the CloudFormation execution role ARN for stage 2?",
+    "isRequired": false,
+    "allowAutofill": true,
+    "default": "$AWS_OIDC_ROLE_ARN"
+  }, {
+    "key": "prod_artifacts_bucket",
+    "question": "What is the S3 bucket name for artifacts for stage 2?",
+    "isRequired": true,
+    "allowAutofill": true,
+    "default": {
+      "keyPath": [
+          { "valueOf": "prod_stage_name"},
+          "artifacts_bucket"
+      ]
+    }
+  }, {
+    "key": "prod_region",
+    "question": "What is the AWS region for stage 2?",
+    "isRequired": true,
+    "allowAutofill": true,
+    "default": {
+      "keyPath": [
+          { "valueOf": "prod_stage_name"},
+          "region"
+      ]
+    }
+  }, {
+    "key": "message_prod_stage_configured",
+    "question": "Stage 2 configured successfully.\n",
+    "kind": "info"
+  }]
+}

--- a/Bitbucket-Pipelines/two-stage-pipeline-template/{{cookiecutter.outputDir}}/bitbucket-pipelines.yml
+++ b/Bitbucket-Pipelines/two-stage-pipeline-template/{{cookiecutter.outputDir}}/bitbucket-pipelines.yml
@@ -1,0 +1,65 @@
+# Prerequisites: Parameter oidc: true in the step configuration and variable AWS_OIDC_ROLE_ARN setup in the Deployment variables https://support.atlassian.com/bitbucket-cloud/docs/set-up-and-monitor-deployments/.
+
+image: atlassian/default-image:2
+
+
+pipelines:
+  default:
+    - step:
+        name: Test
+        script:
+          - echo "Tests go here..."
+          # Add testing logic here
+
+
+  branches:
+    {{ cookiecutter.main_git_branch }}:
+      - parallel:
+        - step:
+            name: Test
+            script:
+              - echo "Tests here..."
+              # Add testing logic here
+        - step:
+            name: Security Scan
+            script:
+              # Run a security scan for sensitive data.
+              # See more security tools at https://bitbucket.org/product/features/pipelines/integrations?&category=security
+              - pipe: atlassian/git-secrets-scan:0.5.1
+      - step:
+          name: Deploy to Testing
+          deployment: Test
+          oidc: true
+          script:
+            # Deploy a new version using OpenID Connect (OIDC) authentication without requiring AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY keys.
+            # Parameter oidc: true in the step configuration and variable AWS_OIDC_ROLE_ARN are required.
+            # More details https://bitbucket.org/atlassian/aws-sam-deploy/
+            - pipe: atlassian/aws-sam-deploy:1.3.1
+              variables:
+                AWS_OIDC_ROLE_ARN: {{cookiecutter.testing_pipeline_execution_role}}
+                AWS_DEFAULT_REGION: {{cookiecutter.testing_region}}
+                S3_BUCKET: {{cookiecutter.testing_artifacts_bucket}}
+                STACK_NAME: {{cookiecutter.testing_stack_name}}
+                SAM_TEMPLATE: {{cookiecutter.sam_template}}
+                {%- if cookiecutter.testing_cloudformation_execution_role %}
+                ROLE_ARN: {{cookiecutter.testing_cloudformation_execution_role}}
+                {%- endif %}
+      - step:
+          name: Deploy to Production
+          deployment: Production
+          trigger: manual
+          oidc: true
+          script:
+            # Deploy a new version using OpenID Connect (OIDC) authentication without requiring AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY keys.
+            # Parameter oidc: true in the step configuration and variable AWS_OIDC_ROLE_ARN are required.
+            # More details https://bitbucket.org/atlassian/aws-sam-deploy/
+            - pipe: atlassian/aws-sam-deploy:1.3.1
+              variables:
+                AWS_OIDC_ROLE_ARN: {{cookiecutter.prod_pipeline_execution_role}}
+                AWS_DEFAULT_REGION: {{cookiecutter.prod_region}}
+                S3_BUCKET: {{cookiecutter.prod_artifacts_bucket}}
+                STACK_NAME: {{cookiecutter.prod_stack_name}}
+                SAM_TEMPLATE: {{cookiecutter.sam_template}}
+                {%- if cookiecutter.prod_cloudformation_execution_role %}
+                ROLE_ARN: {{cookiecutter.prod_cloudformation_execution_role}}
+                {%- endif %}

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -7,6 +7,8 @@ providers:
     id: github-actions
   - displayName: AWS CodePipeline
     id: aws-codepipeline
+  - displayName: Bitbucket Pipelines
+    id: bitbucket-pipelines
 templates:
   - displayName: Two-stage pipeline
     provider: jenkins
@@ -20,3 +22,6 @@ templates:
   - displayName: Two-stage pipeline
     provider: aws-codepipeline
     location: AWS-CodePipeline/two-stage-pipeline-template
+  - displayName: Two-stage pipeline
+    provider: bitbucket-pipelines
+    location: Bitbucket-Pipelines/two-stage-pipeline-template


### PR DESCRIPTION
Hi team,

It would be nice to add [Bitbucket Pipelines](https://support.atlassian.com/bitbucket-cloud/docs/get-started-with-bitbucket-pipelines/) as a CI/CD provider to AWS SAM Pipelines. More and more users request support for this feature.

Bitbucket Pipelines is an integrated CI/CD service built into Bitbucket. It allows you to automatically build, test, and even deploy your code based on a configuration file in your repository. Bitbucket Pipelines is one of the most used CI/CD services.

A pipeline is defined using a YAML file called bitbucket-pipelines.yml, which is located at the root of a repository. For more information on configuring a YAML file, refer to [Configure bitbucket-pipelines.yml](https://support.atlassian.com/bitbucket-cloud/docs/configure-bitbucket-pipelinesyml/). The bitbucket-pipelines.yml file defines a Pipelines builds configuration.

An integration with AWS SAM is provided by [Bitbucket Pipe](https://support.atlassian.com/bitbucket-cloud/docs/what-are-pipes/): [atlassian/aws-sam-deploy](https://bitbucket.org/atlassian/aws-sam-deploy) pipe.

The provider's directory follows recommended structure. The template tested as "Choice 2 - Custom Pipeline Template Location" during "sam pipeline init" workflow.

Would you please let me know if any additional changes are required to the current, aws-sam-cli or other repository?


Best regards,
Oleksandr Kyrdan



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
