### PR TITLE
fix: use ${AWS::Partition} instead of hardcoding

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,13 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.8
+    - uses: aws-actions/setup-sam@v2
+      with:
+        version: 1.27.2
 
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install aws-sam-cli==1.27.2
         python -m pip install pytest~=6.0
 
     - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,13 +12,12 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.8
-    - uses: aws-actions/setup-sam@v2
-      with:
-        version: 1.27.2
 
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        python -m pip install aws-sam-cli==1.27.2
+        python -m pip install markupsafe==2.0.1 # https://github.com/aws/aws-sam-cli/issues/3661#issuecomment-1044340547
         python -m pip install pytest~=6.0
 
     - name: Run tests

--- a/AWS-CodePipeline/two-stage-pipeline-template/{{cookiecutter.outputDir}}/codepipeline.yaml
+++ b/AWS-CodePipeline/two-stage-pipeline-template/{{cookiecutter.outputDir}}/codepipeline.yaml
@@ -157,7 +157,7 @@ Resources:
               -
                 Effect: Allow
                 Action: codepipeline:StartPipelineExecution
-                Resource: !Sub "arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${Pipeline}"
+                Resource: !Sub "arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${Pipeline}"
 
   CloudWatchEventRule:
     Type: AWS::Events::Rule
@@ -168,7 +168,7 @@ Resources:
         detail-type:
           - 'CodeCommit Repository State Change'
         resources:
-          - !Sub "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:${CodeCommitRepositoryName}"
+          - !Sub "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${CodeCommitRepositoryName}"
         detail:
           event:
             - referenceCreated
@@ -178,7 +178,7 @@ Resources:
           referenceName:
             - !If [IsFeatureBranchPipeline, !Ref FeatureGitBranch, !Ref MainGitBranch]
       Targets:
-        - Arn: !Sub "arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${Pipeline}"
+        - Arn: !Sub "arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${Pipeline}"
           RoleArn: !GetAtt CloudWatchEventRole.Arn
           Id: codepipeline-AppPipeline
   {%- endif %}
@@ -417,8 +417,8 @@ Resources:
               - s3:*
             Effect: Allow
             Resource:
-              - !Sub arn:aws:s3:::${PipelineArtifactsBucket}
-              - !Sub arn:aws:s3:::${PipelineArtifactsBucket}/*
+              - !Sub arn:${AWS::Partition}:s3:::${PipelineArtifactsBucket}
+              - !Sub arn:${AWS::Partition}:s3:::${PipelineArtifactsBucket}/*
             Principal:
               AWS:
                 - !GetAtt CodePipelineExecutionRole.Arn
@@ -495,7 +495,7 @@ Resources:
                   - 'codecommit:GetUploadArchiveStatus'
                   - 'codecommit:UploadArchive'
                 Resource:
-                  - !Sub "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:${CodeCommitRepositoryName}"
+                  - !Sub "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${CodeCommitRepositoryName}"
         {%- endif %}
         - PolicyName: CodePipelineCodeAndS3Bucket
           PolicyDocument:
@@ -559,7 +559,7 @@ Resources:
                   - "cloudformation:SetStackPolicy"
                   - "cloudformation:ValidateTemplate"
                 Resource:
-                  - !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*"
+                  - !Sub "arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*"
 
   # PipelineStackCloudFormationExecutionRole is used for the pipeline to self mutate
   PipelineStackCloudFormationExecutionRole:
@@ -612,7 +612,7 @@ Resources:
                   - "logs:CreateLogStream"
                   - "logs:PutLogEvents"
                 Resource:
-                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/*"
+                  - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/*"
         - PolicyName: CodeBuildArtifactsBucket
           PolicyDocument:
             Version: "2012-10-17"
@@ -623,7 +623,7 @@ Resources:
                   - "s3:GetObjectVersion"
                   - "s3:PutObject"
                 Resource:
-                  - !Sub "arn:aws:s3:::${PipelineArtifactsBucket}/*"
+                  - !Sub "arn:${AWS::Partition}:s3:::${PipelineArtifactsBucket}/*"
         - PolicyName: AssumeStagePipExecutionRoles
           PolicyDocument:
             Version: "2012-10-17"


### PR DESCRIPTION
*Issue #, if available:*

Fixes https://github.com/aws/aws-sam-cli-pipeline-init-templates/issues/49

*Description of changes:*

Uses `${AWS::Partition}` instead of hardcoding the partition in ARNs. Used this:

```bash
find ./ -type f -exec sed -i '' -e 's/:aws:/:${AWS::Partition}:/g' {} \;
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
