### PR TITLE
Add OIDC support

### DIFF
--- a/Bitbucket-Pipelines/two-stage-pipeline-template/cookiecutter.json
+++ b/Bitbucket-Pipelines/two-stage-pipeline-template/cookiecutter.json
@@ -15,5 +15,6 @@
   "prod_cloudformation_execution_role": "",
   "prod_artifacts_bucket": "",
   "prod_image_repository": "",
-  "prod_region": ""
+  "prod_region": "",
+  "permissions_provider": ""
 }

--- a/Bitbucket-Pipelines/two-stage-pipeline-template/questions.json
+++ b/Bitbucket-Pipelines/two-stage-pipeline-template/questions.json
@@ -4,6 +4,15 @@
     "question": "\nThis template configures a pipeline that deploys a serverless application to a testing and a production stage.\n",
     "kind": "info"
   }, {
+    "key": "permissions_provider",
+    "question": "Select a user permissions provider.",
+    "options": ["IAM", "OpenID Connect"],
+    "default": "1",
+    "nextQuestion": {
+      "OpenID Connect": "main_git_branch"
+    },
+    "defaultNextQuestion": "pipeline_user_aws_access_key_id_variable_name"
+  },{
     "key": "pipeline_user_aws_access_key_id_variable_name",
     "question": "What is the Bitbucket variable key for pipeline user account access key ID?",
     "default": "AWS_ACCESS_KEY_ID"

--- a/Bitbucket-Pipelines/two-stage-pipeline-template/{{cookiecutter.outputDir}}/assume-role.sh
+++ b/Bitbucket-Pipelines/two-stage-pipeline-template/{{cookiecutter.outputDir}}/assume-role.sh
@@ -2,17 +2,29 @@
 ROLE=$1
 SESSION_NAME=$2
 PROFILE_NAME=$3
+PERMISSIONS_PROVIDER=$4
+TOKEN=$5
 
 unset AWS_SESSION_TOKEN
 
-aws configure --profile sam-pipeline-user set aws_access_key_id "$PIPELINE_USER_ACCESS_KEY_ID"
-aws configure --profile sam-pipeline-user set aws_secret_access_key "$PIPELINE_USER_SECRET_ACCESS_KEY"
+if [ "$PERMISSIONS_PROVIDER" = "IAM" ]
+then
+    aws configure --profile sam-pipeline-user set aws_access_key_id "$PIPELINE_USER_ACCESS_KEY_ID"
+    aws configure --profile sam-pipeline-user set aws_secret_access_key "$PIPELINE_USER_SECRET_ACCESS_KEY"
 
-cred=$(aws sts assume-role --profile sam-pipeline-user \
-                           --role-arn "$ROLE" \
-                           --role-session-name "$SESSION_NAME" \
-                           --query '[Credentials.AccessKeyId,Credentials.SecretAccessKey,Credentials.SessionToken]' \
-                           --output text)
+    cred=$(aws sts assume-role --profile sam-pipeline-user \
+                            --role-arn "$ROLE" \
+                            --role-session-name "$SESSION_NAME" \
+                            --query '[Credentials.AccessKeyId,Credentials.SecretAccessKey,Credentials.SessionToken]' \
+                            --output text)
+else
+    # Use assume-role-with-web-identity instead of assume-role
+    cred=$(aws sts assume-role-with-web-identity --role-arn "$ROLE" \
+                            --role-session-name "$SESSION_NAME" \
+                            --web-identity-token "$TOKEN" \
+                            --query '[Credentials.AccessKeyId,Credentials.SecretAccessKey,Credentials.SessionToken]' \
+                            --output text)
+fi
 
 ACCESS_KEY_ID=$(echo "$cred" | awk '{ print $1 }')
 aws configure --profile "$PROFILE_NAME" set aws_access_key_id "$ACCESS_KEY_ID"

--- a/Bitbucket-Pipelines/two-stage-pipeline-template/{{cookiecutter.outputDir}}/bitbucket-pipelines.yml
+++ b/Bitbucket-Pipelines/two-stage-pipeline-template/{{cookiecutter.outputDir}}/bitbucket-pipelines.yml
@@ -4,11 +4,16 @@ pipelines:
   branches:
     feature:
       - step:
+          oidc: true
           name: Build and Package
           script:
             - export SAM_TEMPLATE="{{ cookiecutter.sam_template }}"
-            - export PIPELINE_USER_ACCESS_KEY_ID=${{ "{" }}{{cookiecutter.pipeline_user_aws_access_key_id_variable_name}}{{ "}" }}
-            - export PIPELINE_USER_SECRET_ACCESS_KEY=${{ "{" }}{{cookiecutter.pipeline_user_aws_secret_access_key_variable_name}}{{ "}" }}
+            - export PERMISSIONS_PROVIDER="{{ cookiecutter.permissions_provider }}"
+            - |
+              if [ "$PERMISSIONS_PROVIDER" = IAM ]; then
+                export PIPELINE_USER_ACCESS_KEY_ID=${{ "{" }}{{cookiecutter.pipeline_user_aws_access_key_id_variable_name}}{{ "}" }}
+                export PIPELINE_USER_SECRET_ACCESS_KEY=${{ "{" }}{{cookiecutter.pipeline_user_aws_secret_access_key_variable_name}}{{ "}" }}
+              fi
             - export TESTING_PIPELINE_EXECUTION_ROLE="{{ cookiecutter.testing_pipeline_execution_role }}"
             - export TESTING_CLOUDFORMATION_EXECUTION_ROLE="{{ cookiecutter.testing_cloudformation_execution_role }}"
             - export TESTING_ARTIFACTS_BUCKET="{{ cookiecutter.testing_artifacts_bucket }}"
@@ -23,7 +28,14 @@ pipelines:
             #- export TESTING_IMAGE_REPOSITORY='0123456789.dkr.ecr.region.amazonaws.com/repository-name'
             {% endif -%}
             - sam build --template $SAM_TEMPLATE --use-container
-            - source assume-role.sh $TESTING_PIPELINE_EXECUTION_ROLE testing-stage-packaging testing-stage
+            - |
+              if [ "$PERMISSIONS_PROVIDER" = "OpenID Connect" ]; then
+                export AWS_REGION=$TESTING_REGION
+                export AWS_ROLE_ARN=$TESTING_PIPELINE_EXECUTION_ROLE
+                export AWS_WEB_IDENTITY_TOKEN_FILE=$(pwd)/web-identity-token
+                echo $BITBUCKET_STEP_OIDC_TOKEN > $(pwd)/web-identity-token
+              fi
+            - source assume-role.sh $TESTING_PIPELINE_EXECUTION_ROLE testing-stage-packaging testing-stage "$PERMISSIONS_PROVIDER" $BITBUCKET_STEP_OIDC_TOKEN
             - >
               sam package --profile testing-stage
               --s3-bucket $TESTING_ARTIFACTS_BUCKET
@@ -49,11 +61,16 @@ pipelines:
 
     {{ cookiecutter.main_git_branch }}:
       - step:
+          oidc: true
           name: Build and Package
           script:
             - export SAM_TEMPLATE="{{ cookiecutter.sam_template }}"
-            - export PIPELINE_USER_ACCESS_KEY_ID=${{ "{" }}{{cookiecutter.pipeline_user_aws_access_key_id_variable_name}}{{ "}" }}
-            - export PIPELINE_USER_SECRET_ACCESS_KEY=${{ "{" }}{{cookiecutter.pipeline_user_aws_secret_access_key_variable_name}}{{ "}" }}
+            - export PERMISSIONS_PROVIDER="{{ cookiecutter.permissions_provider }}"
+            - |
+              if [ "$PERMISSIONS_PROVIDER" = IAM ]; then
+                export PIPELINE_USER_ACCESS_KEY_ID=${{ "{" }}{{cookiecutter.pipeline_user_aws_access_key_id_variable_name}}{{ "}" }}
+                export PIPELINE_USER_SECRET_ACCESS_KEY=${{ "{" }}{{cookiecutter.pipeline_user_aws_secret_access_key_variable_name}}{{ "}" }}
+              fi
             - export TESTING_PIPELINE_EXECUTION_ROLE="{{ cookiecutter.testing_pipeline_execution_role }}"
             - export TESTING_CLOUDFORMATION_EXECUTION_ROLE="{{ cookiecutter.testing_cloudformation_execution_role }}"
             - export TESTING_ARTIFACTS_BUCKET="{{ cookiecutter.testing_artifacts_bucket }}"
@@ -79,7 +96,14 @@ pipelines:
             #- export PRODUCTION_IMAGE_REPOSITORY='0123456789.dkr.ecr.region.amazonaws.com/repository-name'
             {% endif -%}
             - sam build --template $SAM_TEMPLATE --use-container
-            - source assume-role.sh $TESTING_PIPELINE_EXECUTION_ROLE testing-stage-packaging testing-stage
+            - |
+              if [ "$PERMISSIONS_PROVIDER" = "OpenID Connect" ]; then
+                export AWS_REGION=$TESTING_REGION
+                export AWS_ROLE_ARN=$TESTING_PIPELINE_EXECUTION_ROLE
+                export AWS_WEB_IDENTITY_TOKEN_FILE=$(pwd)/web-identity-token
+                echo $BITBUCKET_STEP_OIDC_TOKEN > $(pwd)/web-identity-token
+              fi
+            - source assume-role.sh $TESTING_PIPELINE_EXECUTION_ROLE testing-stage-packaging testing-stage "$PERMISSIONS_PROVIDER" $BITBUCKET_STEP_OIDC_TOKEN
             - >
               sam package --profile testing-stage
               --s3-bucket $TESTING_ARTIFACTS_BUCKET
@@ -88,7 +112,12 @@ pipelines:
               --image-repository ${TESTING_IMAGE_REPOSITORY}
               {%- endif %}
               --output-template-file packaged-testing.yaml
-            - source assume-role.sh $PRODUCTION_PIPELINE_EXECUTION_ROLE testing-stage-packaging production-stage
+            - |
+              if [ "$PERMISSIONS_PROVIDER" = "OpenID Connect" ]; then
+                export AWS_REGION=$PRODUCTION_REGION
+                export AWS_ROLE_ARN=$PRODUCTION_PIPELINE_EXECUTION_ROLE
+              fi
+            - source assume-role.sh $PRODUCTION_PIPELINE_EXECUTION_ROLE testing-stage-packaging production-stage "$PERMISSIONS_PROVIDER" $BITBUCKET_STEP_OIDC_TOKEN
             - >
               sam package --profile production-stage
               --s3-bucket $PRODUCTION_ARTIFACTS_BUCKET
@@ -103,11 +132,16 @@ pipelines:
           services:
             - docker
       - step:
+          oidc: true
           name: Deploy to Test
           script:
             - export SAM_TEMPLATE="{{ cookiecutter.sam_template }}"
-            - export PIPELINE_USER_ACCESS_KEY_ID=${{ "{" }}{{cookiecutter.pipeline_user_aws_access_key_id_variable_name}}{{ "}" }}
-            - export PIPELINE_USER_SECRET_ACCESS_KEY=${{ "{" }}{{cookiecutter.pipeline_user_aws_secret_access_key_variable_name}}{{ "}" }}
+            - export PERMISSIONS_PROVIDER="{{ cookiecutter.permissions_provider }}"
+            - |
+              if [ "$PERMISSIONS_PROVIDER" = IAM ]; then
+                export PIPELINE_USER_ACCESS_KEY_ID=${{ "{" }}{{cookiecutter.pipeline_user_aws_access_key_id_variable_name}}{{ "}" }}
+                export PIPELINE_USER_SECRET_ACCESS_KEY=${{ "{" }}{{cookiecutter.pipeline_user_aws_secret_access_key_variable_name}}{{ "}" }}
+              fi
             - export TESTING_PIPELINE_EXECUTION_ROLE="{{ cookiecutter.testing_pipeline_execution_role }}"
             - export TESTING_CLOUDFORMATION_EXECUTION_ROLE="{{ cookiecutter.testing_cloudformation_execution_role }}"
             - export TESTING_ARTIFACTS_BUCKET="{{ cookiecutter.testing_artifacts_bucket }}"
@@ -121,7 +155,14 @@ pipelines:
             # prod "sam package" and "sam deploy" commands.'
             # - export TESTING_IMAGE_REPOSITORY='0123456789.dkr.ecr.region.amazonaws.com/repository-name'
             {% endif -%}
-            - source assume-role.sh $TESTING_PIPELINE_EXECUTION_ROLE testing-stage-packaging testing-stage
+            - |
+              if [ "$PERMISSIONS_PROVIDER" = "OpenID Connect" ]; then
+                export AWS_REGION=$TESTING_REGION
+                export AWS_ROLE_ARN=$TESTING_PIPELINE_EXECUTION_ROLE
+                export AWS_WEB_IDENTITY_TOKEN_FILE=$(pwd)/web-identity-token
+                echo $BITBUCKET_STEP_OIDC_TOKEN > $(pwd)/web-identity-token
+              fi
+            - source assume-role.sh $TESTING_PIPELINE_EXECUTION_ROLE testing-stage-packaging testing-stage "$PERMISSIONS_PROVIDER" $BITBUCKET_STEP_OIDC_TOKEN
             - >
               sam deploy --profile testing-stage
               --stack-name ${TESTING_STACK_NAME}
@@ -140,11 +181,16 @@ pipelines:
           services:
             - docker
       - step:
+          oidc: true
           name: Deploy to Prod
           script:
             - export SAM_TEMPLATE="{{ cookiecutter.sam_template }}"
-            - export PIPELINE_USER_ACCESS_KEY_ID=${{ "{" }}{{cookiecutter.pipeline_user_aws_access_key_id_variable_name}}{{ "}" }}
-            - export PIPELINE_USER_SECRET_ACCESS_KEY=${{ "{" }}{{cookiecutter.pipeline_user_aws_secret_access_key_variable_name}}{{ "}" }}
+            - export PERMISSIONS_PROVIDER="{{ cookiecutter.permissions_provider }}"
+            - |
+              if [ "$PERMISSIONS_PROVIDER" = IAM ]; then
+                export PIPELINE_USER_ACCESS_KEY_ID=${{ "{" }}{{cookiecutter.pipeline_user_aws_access_key_id_variable_name}}{{ "}" }}
+                export PIPELINE_USER_SECRET_ACCESS_KEY=${{ "{" }}{{cookiecutter.pipeline_user_aws_secret_access_key_variable_name}}{{ "}" }}
+              fi
             - export PRODUCTION_PIPELINE_EXECUTION_ROLE="{{ cookiecutter.prod_pipeline_execution_role }}"
             - export PRODUCTION_CLOUDFORMATION_EXECUTION_ROLE="{{ cookiecutter.prod_cloudformation_execution_role }}"
             - export PRODUCTION_ARTIFACTS_BUCKET="{{ cookiecutter.prod_artifacts_bucket }}"
@@ -158,7 +204,14 @@ pipelines:
             # prod "sam package" and "sam deploy" commands.'
             # - export PRODUCTION_IMAGE_REPOSITORY='0123456789.dkr.ecr.region.amazonaws.com/repository-name'
             {% endif -%}
-            - source assume-role.sh $PRODUCTION_PIPELINE_EXECUTION_ROLE testing-stage-packaging production-stage
+            - |
+              if [ "$PERMISSIONS_PROVIDER" = "OpenID Connect" ]; then
+                export AWS_REGION=$PRODUCTION_REGION
+                export AWS_ROLE_ARN=$PRODUCTION_PIPELINE_EXECUTION_ROLE
+                export AWS_WEB_IDENTITY_TOKEN_FILE=$(pwd)/web-identity-token
+                echo $BITBUCKET_STEP_OIDC_TOKEN > $(pwd)/web-identity-token
+              fi
+            - source assume-role.sh $PRODUCTION_PIPELINE_EXECUTION_ROLE testing-stage-packaging production-stage "$PERMISSIONS_PROVIDER" $BITBUCKET_STEP_OIDC_TOKEN
             - >
               sam deploy --profile production-stage
               --stack-name ${PRODUCTION_STACK_NAME}

--- a/GitHub-Actions/two-stage-pipeline-template/cookiecutter.json
+++ b/GitHub-Actions/two-stage-pipeline-template/cookiecutter.json
@@ -1,7 +1,7 @@
 {
   "outputDir": "aws-sam-pipeline",
-  "pipeline_user_aws_access_key_id_variable_name": "",
-  "pipeline_user_aws_secret_access_key_variable_name": "",
+  "pipeline_user_aws_access_key_id_variable_name": "AWS_ACCESS_KEY_ID",
+  "pipeline_user_aws_secret_access_key_variable_name": "AWS_SECRET_ACCESS_KEY",
   "main_git_branch": "",
   "sam_template": "",
   "testing_stack_name": "",
@@ -15,5 +15,6 @@
   "prod_cloudformation_execution_role": "",
   "prod_artifacts_bucket": "",
   "prod_image_repository": "",
-  "prod_region": ""
+  "prod_region": "",
+  "permissions_provider": ""
 }

--- a/GitHub-Actions/two-stage-pipeline-template/questions.json
+++ b/GitHub-Actions/two-stage-pipeline-template/questions.json
@@ -4,6 +4,15 @@
     "question": "\nThis template configures a pipeline that deploys a serverless application to a testing and a production stage.\n",
     "kind": "info"
   }, {
+    "key": "permissions_provider",
+    "question": "Select a user permissions provider.",
+    "options": ["IAM", "OpenID Connect"],
+    "default": "1",
+    "nextQuestion": {
+      "OpenID Connect": "main_git_branch"
+    },
+    "defaultNextQuestion": "pipeline_user_aws_access_key_id_variable_name"
+  },{
     "key": "pipeline_user_aws_access_key_id_variable_name",
     "question": "What is the GitHub secret name for pipeline user account access key ID?",
     "default": "AWS_ACCESS_KEY_ID"

--- a/GitHub-Actions/two-stage-pipeline-template/{{cookiecutter.outputDir}}/.github/workflows/pipeline.yaml
+++ b/GitHub-Actions/two-stage-pipeline-template/{{cookiecutter.outputDir}}/.github/workflows/pipeline.yaml
@@ -211,12 +211,12 @@ jobs:
           role-duration-seconds: 3600
           role-skip-session-tagging: true      
 
-      - name: Assume the testing pipeline user role via OIDC
+      - name: Assume the prod pipeline user role via OIDC
         if: env.PERMISSIONS_PROVIDER == 'OpenID Connect'
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-region: {{ '${{ env.TESTING_REGION }}' }}
-          role-to-assume: {{ '${{ env.TESTING_PIPELINE_EXECUTION_ROLE }}' }}
+          aws-region: {{ '${{ env.PROD_REGION }}' }}
+          role-to-assume: {{ '${{ env.PROD_PIPELINE_EXECUTION_ROLE }}' }}
           role-session-name: testing-packaging
           role-duration-seconds: 3600
           role-skip-session-tagging: true
@@ -325,12 +325,12 @@ jobs:
           role-duration-seconds: 3600
           role-skip-session-tagging: true
         
-      - name: Assume the testing pipeline user role via OIDC
+      - name: Assume the prod pipeline user role via OIDC
         if: env.PERMISSIONS_PROVIDER == 'OpenID Connect'
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-region: {{ '${{ env.TESTING_REGION }}' }}
-          role-to-assume: {{ '${{ env.TESTING_PIPELINE_EXECUTION_ROLE }}' }}
+          aws-region: {{ '${{ env.PROD_REGION }}' }}
+          role-to-assume: {{ '${{ env.PROD_PIPELINE_EXECUTION_ROLE }}' }}
           role-session-name: testing-packaging
           role-duration-seconds: 3600
           role-skip-session-tagging: true

--- a/GitHub-Actions/two-stage-pipeline-template/{{cookiecutter.outputDir}}/.github/workflows/pipeline.yaml
+++ b/GitHub-Actions/two-stage-pipeline-template/{{cookiecutter.outputDir}}/.github/workflows/pipeline.yaml
@@ -10,8 +10,7 @@ on:
       - 'feature**'
 
 env:
-  PIPELINE_USER_ACCESS_KEY_ID: ${{ "{{" }} secrets.{{cookiecutter.pipeline_user_aws_access_key_id_variable_name}} {{ "}}" }}
-  PIPELINE_USER_SECRET_ACCESS_KEY: ${{ "{{" }} secrets.{{cookiecutter.pipeline_user_aws_secret_access_key_variable_name}} {{ "}}" }}
+  PERMISSIONS_PROVIDER: {{cookiecutter.permissions_provider}}
   SAM_TEMPLATE: {{cookiecutter.sam_template}}
   TESTING_STACK_NAME: {{cookiecutter.testing_stack_name}}
   TESTING_PIPELINE_EXECUTION_ROLE: {{cookiecutter.testing_pipeline_execution_role}}
@@ -39,6 +38,10 @@ env:
   # PROD_IMAGE_REPOSITORY = '0123456789.dkr.ecr.region.amazonaws.com/repository-name'
   {% endif -%}
   PROD_REGION: {{cookiecutter.prod_region}}
+  
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   test:
@@ -57,11 +60,25 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: aws-actions/setup-sam@v1
 
-      - name: Assume the testing pipeline user role
+      - name: Assume the testing pipeline user role via IAM user
+        if: env.PERMISSIONS_PROVIDER == 'IAM'
+        env:
+          PIPELINE_USER_ACCESS_KEY_ID: ${{ "{{" }} secrets.{{cookiecutter.pipeline_user_aws_access_key_id_variable_name}} {{ "}}" }}
+          PIPELINE_USER_SECRET_ACCESS_KEY: ${{ "{{" }} secrets.{{cookiecutter.pipeline_user_aws_secret_access_key_variable_name}} {{ "}}" }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: {{ '${{ env.PIPELINE_USER_ACCESS_KEY_ID }}' }}
           aws-secret-access-key: {{ '${{ env.PIPELINE_USER_SECRET_ACCESS_KEY }}' }}
+          aws-region: {{ '${{ env.TESTING_REGION }}' }}
+          role-to-assume: {{ '${{ env.TESTING_PIPELINE_EXECUTION_ROLE }}' }}
+          role-session-name: testing-packaging
+          role-duration-seconds: 3600
+          role-skip-session-tagging: true
+      
+      - name: Assume the testing pipeline user role via OIDC
+        if: env.PERMISSIONS_PROVIDER == 'OpenID Connect'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
           aws-region: {{ '${{ env.TESTING_REGION }}' }}
           role-to-assume: {{ '${{ env.TESTING_PIPELINE_EXECUTION_ROLE }}' }}
           role-session-name: testing-packaging
@@ -90,6 +107,10 @@ jobs:
       - run: sam build --template ${SAM_TEMPLATE} --use-container
 
       - name: Assume the testing pipeline user role
+        if: env.PERMISSIONS_PROVIDER == 'IAM'
+        env:
+          PIPELINE_USER_ACCESS_KEY_ID: ${{ "{{" }} secrets.{{cookiecutter.pipeline_user_aws_access_key_id_variable_name}} {{ "}}" }}
+          PIPELINE_USER_SECRET_ACCESS_KEY: ${{ "{{" }} secrets.{{cookiecutter.pipeline_user_aws_secret_access_key_variable_name}} {{ "}}" }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: {{ '${{ env.PIPELINE_USER_ACCESS_KEY_ID }}' }}
@@ -97,6 +118,16 @@ jobs:
           aws-region: {{ '${{ env.TESTING_REGION }}' }}
           role-to-assume: {{ '${{ env.TESTING_PIPELINE_EXECUTION_ROLE }}' }}
           role-session-name: feature-deployment
+          role-duration-seconds: 3600
+          role-skip-session-tagging: true
+                
+      - name: Assume the testing pipeline user role via OIDC
+        if: env.PERMISSIONS_PROVIDER == 'OpenID Connect'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: {{ '${{ env.TESTING_REGION }}' }}
+          role-to-assume: {{ '${{ env.TESTING_PIPELINE_EXECUTION_ROLE }}' }}
+          role-session-name: testing-packaging
           role-duration-seconds: 3600
           role-skip-session-tagging: true
 
@@ -126,10 +157,24 @@ jobs:
         run: sam build --template ${SAM_TEMPLATE} --use-container
 
       - name: Assume the testing pipeline user role
+        if: env.PERMISSIONS_PROVIDER == 'IAM'
+        env:
+          PIPELINE_USER_ACCESS_KEY_ID: ${{ "{{" }} secrets.{{cookiecutter.pipeline_user_aws_access_key_id_variable_name}} {{ "}}" }}
+          PIPELINE_USER_SECRET_ACCESS_KEY: ${{ "{{" }} secrets.{{cookiecutter.pipeline_user_aws_secret_access_key_variable_name}} {{ "}}" }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: {{ '${{ env.PIPELINE_USER_ACCESS_KEY_ID }}' }}
           aws-secret-access-key: {{ '${{ env.PIPELINE_USER_SECRET_ACCESS_KEY }}' }}
+          aws-region: {{ '${{ env.TESTING_REGION }}' }}
+          role-to-assume: {{ '${{ env.TESTING_PIPELINE_EXECUTION_ROLE }}' }}
+          role-session-name: testing-packaging
+          role-duration-seconds: 3600
+          role-skip-session-tagging: true
+                
+      - name: Assume the testing pipeline user role via OIDC
+        if: env.PERMISSIONS_PROVIDER == 'OpenID Connect'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
           aws-region: {{ '${{ env.TESTING_REGION }}' }}
           role-to-assume: {{ '${{ env.TESTING_PIPELINE_EXECUTION_ROLE }}' }}
           role-session-name: testing-packaging
@@ -152,6 +197,10 @@ jobs:
           path: packaged-testing.yaml
 
       - name: Assume the prod pipeline user role
+        if: env.PERMISSIONS_PROVIDER == 'IAM'
+        env:
+          PIPELINE_USER_ACCESS_KEY_ID: ${{ "{{" }} secrets.{{cookiecutter.pipeline_user_aws_access_key_id_variable_name}} {{ "}}" }}
+          PIPELINE_USER_SECRET_ACCESS_KEY: ${{ "{{" }} secrets.{{cookiecutter.pipeline_user_aws_secret_access_key_variable_name}} {{ "}}" }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: {{ '${{ env.PIPELINE_USER_ACCESS_KEY_ID }}' }}
@@ -159,6 +208,16 @@ jobs:
           aws-region: {{ '${{ env.PROD_REGION }}' }}
           role-to-assume: {{ '${{ env.PROD_PIPELINE_EXECUTION_ROLE }}' }}
           role-session-name: prod-packaging
+          role-duration-seconds: 3600
+          role-skip-session-tagging: true      
+
+      - name: Assume the testing pipeline user role via OIDC
+        if: env.PERMISSIONS_PROVIDER == 'OpenID Connect'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: {{ '${{ env.TESTING_REGION }}' }}
+          role-to-assume: {{ '${{ env.TESTING_PIPELINE_EXECUTION_ROLE }}' }}
+          role-session-name: testing-packaging
           role-duration-seconds: 3600
           role-skip-session-tagging: true
 
@@ -190,6 +249,10 @@ jobs:
           name: packaged-testing.yaml
 
       - name: Assume the testing pipeline user role
+        if: env.PERMISSIONS_PROVIDER == 'IAM'
+        env:
+          PIPELINE_USER_ACCESS_KEY_ID: ${{ "{{" }} secrets.{{cookiecutter.pipeline_user_aws_access_key_id_variable_name}} {{ "}}" }}
+          PIPELINE_USER_SECRET_ACCESS_KEY: ${{ "{{" }} secrets.{{cookiecutter.pipeline_user_aws_secret_access_key_variable_name}} {{ "}}" }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: {{ '${{ env.PIPELINE_USER_ACCESS_KEY_ID }}' }}
@@ -197,6 +260,16 @@ jobs:
           aws-region: {{ '${{ env.TESTING_REGION }}' }}
           role-to-assume: {{ '${{ env.TESTING_PIPELINE_EXECUTION_ROLE }}' }}
           role-session-name: testing-deployment
+          role-duration-seconds: 3600
+          role-skip-session-tagging: true
+
+      - name: Assume the testing pipeline user role via OIDC
+        if: env.PERMISSIONS_PROVIDER == 'OpenID Connect'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: {{ '${{ env.TESTING_REGION }}' }}
+          role-to-assume: {{ '${{ env.TESTING_PIPELINE_EXECUTION_ROLE }}' }}
+          role-session-name: testing-packaging
           role-duration-seconds: 3600
           role-skip-session-tagging: true
 
@@ -238,6 +311,10 @@ jobs:
           name: packaged-prod.yaml
 
       - name: Assume the prod pipeline user role
+        if: env.PERMISSIONS_PROVIDER == 'IAM'
+        env:
+          PIPELINE_USER_ACCESS_KEY_ID: ${{ "{{" }} secrets.{{cookiecutter.pipeline_user_aws_access_key_id_variable_name}} {{ "}}" }}
+          PIPELINE_USER_SECRET_ACCESS_KEY: ${{ "{{" }} secrets.{{cookiecutter.pipeline_user_aws_secret_access_key_variable_name}} {{ "}}" }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: {{ '${{ env.PIPELINE_USER_ACCESS_KEY_ID }}' }}
@@ -245,6 +322,16 @@ jobs:
           aws-region: {{ '${{ env.PROD_REGION }}' }}
           role-to-assume: {{ '${{ env.PROD_PIPELINE_EXECUTION_ROLE }}' }}
           role-session-name: prod-deployment
+          role-duration-seconds: 3600
+          role-skip-session-tagging: true
+        
+      - name: Assume the testing pipeline user role via OIDC
+        if: env.PERMISSIONS_PROVIDER == 'OpenID Connect'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: {{ '${{ env.TESTING_REGION }}' }}
+          role-to-assume: {{ '${{ env.TESTING_PIPELINE_EXECUTION_ROLE }}' }}
+          role-session-name: testing-packaging
           role-duration-seconds: 3600
           role-skip-session-tagging: true
 

--- a/Gitlab/two-stage-pipeline-template/cookiecutter.json
+++ b/Gitlab/two-stage-pipeline-template/cookiecutter.json
@@ -15,5 +15,6 @@
   "prod_cloudformation_execution_role": "",
   "prod_artifacts_bucket":  "",
   "prod_image_repository":  "",
-  "prod_region": ""
+  "prod_region": "",
+  "permissions_provider": ""
 }

--- a/Gitlab/two-stage-pipeline-template/questions.json
+++ b/Gitlab/two-stage-pipeline-template/questions.json
@@ -4,6 +4,15 @@
     "question": "\nThis template configures a pipeline that deploys a serverless application to a testing and a production stage.\n",
     "kind": "info"
   }, {
+    "key": "permissions_provider",
+    "question": "Select a user permissions provider.",
+    "options": ["IAM", "OpenID Connect"],
+    "default": "1",
+    "nextQuestion": {
+      "OpenID Connect": "main_git_branch"
+    },
+    "defaultNextQuestion": "pipeline_user_aws_access_key_id_variable_name"
+  },{
     "key": "pipeline_user_aws_access_key_id_variable_name",
     "question": "What is the GitLab variable key for pipeline user account access key ID?",
     "default": "AWS_ACCESS_KEY_ID"

--- a/Gitlab/two-stage-pipeline-template/{{cookiecutter.outputDir}}/.gitlab-ci.yml
+++ b/Gitlab/two-stage-pipeline-template/{{cookiecutter.outputDir}}/.gitlab-ci.yml
@@ -1,5 +1,6 @@
 variables:
   SAM_TEMPLATE: {{cookiecutter.sam_template}}
+  PERMISSIONS_PROVIDER: {{cookiecutter.permissions_provider}}
   PIPELINE_USER_ACCESS_KEY_ID: ${{ "{" }}{{cookiecutter.pipeline_user_aws_access_key_id_variable_name}}{{ "}" }}
   PIPELINE_USER_SECRET_ACCESS_KEY: ${{ "{" }}{{cookiecutter.pipeline_user_aws_secret_access_key_variable_name}}{{ "}" }}
   TESTING_STACK_NAME: {{cookiecutter.testing_stack_name}}
@@ -72,7 +73,7 @@ build-and-deploy-feature:
   only:
     - /^feature-.*$/
   script:
-    - . assume-role.sh ${TESTING_PIPELINE_EXECUTION_ROLE} feature-deployment
+    - . assume-role.sh ${TESTING_PIPELINE_EXECUTION_ROLE} feature-deployment "${PERMISSIONS_PROVIDER}"
     - sam build --template ${SAM_TEMPLATE} --use-container
     - sam deploy --stack-name $(echo ${CI_COMMIT_REF_NAME} | tr -cd '[a-zA-Z0-9-]')
                  --capabilities CAPABILITY_IAM
@@ -94,7 +95,7 @@ build-and-package:
   script:
     - sam build --template ${SAM_TEMPLATE} --use-container
 
-    - . assume-role.sh ${TESTING_PIPELINE_EXECUTION_ROLE} testing-stage-packaging
+    - . assume-role.sh ${TESTING_PIPELINE_EXECUTION_ROLE} testing-stage-packaging "${PERMISSIONS_PROVIDER}"
 
     - sam package --s3-bucket ${TESTING_ARTIFACTS_BUCKET}
                    {%- if cookiecutter.testing_image_repository %}
@@ -103,7 +104,7 @@ build-and-package:
                    --region ${TESTING_REGION}
                    --output-template-file packaged-testing.yaml
 
-    - . assume-role.sh ${PROD_PIPELINE_EXECUTION_ROLE} prod-stage-packaging
+    - . assume-role.sh ${PROD_PIPELINE_EXECUTION_ROLE} prod-stage-packaging "${PERMISSIONS_PROVIDER}"
 
     - sam package --s3-bucket ${PROD_ARTIFACTS_BUCKET}
                   {%- if cookiecutter.prod_image_repository %}
@@ -125,7 +126,7 @@ deploy-testing:
   only:
     - {{cookiecutter.main_git_branch}}
   script:
-    - . assume-role.sh ${TESTING_PIPELINE_EXECUTION_ROLE} testing-deployment
+    - . assume-role.sh ${TESTING_PIPELINE_EXECUTION_ROLE} testing-deployment "${PERMISSIONS_PROVIDER}"
     - sam deploy --stack-name ${TESTING_STACK_NAME}
                  --template packaged-testing.yaml
                  --capabilities CAPABILITY_IAM
@@ -156,7 +157,7 @@ deploy-prod:
   only:
     - {{cookiecutter.main_git_branch}}
   script:
-    - . assume-role.sh ${PROD_PIPELINE_EXECUTION_ROLE} prod-deployment
+    - . assume-role.sh ${PROD_PIPELINE_EXECUTION_ROLE} prod-deployment "${PERMISSIONS_PROVIDER}"
     - sam deploy --stack-name ${PROD_STACK_NAME}
                  --template packaged-prod.yaml
                  --capabilities CAPABILITY_IAM

--- a/Gitlab/two-stage-pipeline-template/{{cookiecutter.outputDir}}/assume-role.sh
+++ b/Gitlab/two-stage-pipeline-template/{{cookiecutter.outputDir}}/assume-role.sh
@@ -1,21 +1,33 @@
 #!/bin/bash
 ROLE=$1
 SESSION_NAME=$2
+PERMISSIONS_PROVIDER=$3
 
 unset AWS_SESSION_TOKEN
 export AWS_ACCESS_KEY_ID=$PIPELINE_USER_ACCESS_KEY_ID
 export AWS_SECRET_ACCESS_KEY=$PIPELINE_USER_SECRET_ACCESS_KEY
 
-cred=$(aws sts assume-role --role-arn "$ROLE" \
-                           --role-session-name "$SESSION_NAME" \
-                           --query '[Credentials.AccessKeyId,Credentials.SecretAccessKey,Credentials.SessionToken]' \
-                           --output text)
+if [ "$PERMISSIONS_PROVIDER" = "OpenID Connect" ]
+then
+    # Use assume-role-with-web-identity instead of assume-role
+    cred=$(aws sts assume-role-with-web-identity --role-arn "$ROLE" \
+                            --role-session-name "$SESSION_NAME" \
+                            --web-identity-token $CI_JOB_JWT_V2 \
+                            --query '[Credentials.AccessKeyId,Credentials.SecretAccessKey,Credentials.SessionToken]' \
+                            --output text)
 
-ACCESS_KEY_ID=$(echo "$cred" | awk '{ print $1 }')
-export AWS_ACCESS_KEY_ID=$ACCESS_KEY_ID
+else
+    cred=$(aws sts assume-role --role-arn "$ROLE" \
+                        --role-session-name "$SESSION_NAME" \
+                        --query '[Credentials.AccessKeyId,Credentials.SecretAccessKey,Credentials.SessionToken]' \
+                        --output text)
+fi
+    ACCESS_KEY_ID=$(echo "$cred" | awk '{ print $1 }')
+    export AWS_ACCESS_KEY_ID=$ACCESS_KEY_ID
 
-SECRET_ACCESS_KEY=$(echo "$cred" | awk '{ print $2 }')
-export AWS_SECRET_ACCESS_KEY=$SECRET_ACCESS_KEY
+    SECRET_ACCESS_KEY=$(echo "$cred" | awk '{ print $2 }')
+    export AWS_SECRET_ACCESS_KEY=$SECRET_ACCESS_KEY
 
-SESSION_TOKEN=$(echo "$cred" | awk '{ print $3 }')
-export AWS_SESSION_TOKEN=$SESSION_TOKEN
+    SESSION_TOKEN=$(echo "$cred" | awk '{ print $3 }')
+    export AWS_SESSION_TOKEN=$SESSION_TOKEN
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changes the templates for GitHub Actions, GitLab, and Bitbucket to use OIDC to assume the pipeline execution role if the user chooses OIDC as their permissions provider

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
