### PR TITLE
initialise ssm client

### DIFF
--- a/AWS-CodePipeline/sam-monorepo-pipeline-template/{{cookiecutter.outputDir}}/codepipeline.yaml
+++ b/AWS-CodePipeline/sam-monorepo-pipeline-template/{{cookiecutter.outputDir}}/codepipeline.yaml
@@ -531,6 +531,7 @@ Resources:
         logger = Logger()
         cc = boto3.client('codecommit')
         cp = boto3.client('codepipeline')
+        ssm = boto3.client('ssm')
         ssm_prefix = os.environ.get('SSM_PREFIX', '')
         app_dir = os.environ.get('APP_DIR_IN_MONOREPO')
         pipeline_name = os.environ.get('PIPELINE_NAME')


### PR DESCRIPTION
Issue #60 

Initialise boto3 ssm client to prevent throwing NameError on invocation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
