### PR TITLE
Use `use-installer` for `setup-sam`

### DIFF
--- a/GitHub-Actions/two-stage-pipeline-template/{{cookiecutter.outputDir}}/.github/workflows/pipeline.yaml
+++ b/GitHub-Actions/two-stage-pipeline-template/{{cookiecutter.outputDir}}/.github/workflows/pipeline.yaml
@@ -63,10 +63,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
       - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
 
       - name: Assume the testing pipeline user role
         uses: aws-actions/configure-aws-credentials@v1-node16
@@ -100,10 +99,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
       - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
       - run: sam build --template ${SAM_TEMPLATE} --use-container
 
       - name: Assume the testing pipeline user role
@@ -138,10 +136,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
       - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
 
       - name: Build resources
         run: sam build --template ${SAM_TEMPLATE} --use-container
@@ -208,10 +205,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
       - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
       - uses: actions/download-artifact@v2
         with:
           name: packaged-testing.yaml
@@ -260,10 +256,9 @@ jobs:
     # environment: <configured-environment>
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
       - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
       - uses: actions/download-artifact@v2
         with:
           name: packaged-prod.yaml

--- a/tests/testfile_github/expected_iam.yaml
+++ b/tests/testfile_github/expected_iam.yaml
@@ -40,10 +40,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
       - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
 
       - name: Assume the testing pipeline user role
         uses: aws-actions/configure-aws-credentials@v1-node16
@@ -75,10 +74,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
       - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
       - run: sam build --template ${SAM_TEMPLATE} --use-container
 
       - name: Assume the testing pipeline user role
@@ -109,10 +107,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
       - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
 
       - name: Build resources
         run: sam build --template ${SAM_TEMPLATE} --use-container
@@ -171,10 +168,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
       - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
       - uses: actions/download-artifact@v2
         with:
           name: packaged-testing.yaml
@@ -219,10 +215,9 @@ jobs:
     # environment: <configured-environment>
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
       - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
       - uses: actions/download-artifact@v2
         with:
           name: packaged-prod.yaml

--- a/tests/testfile_github/expected_oidc.yaml
+++ b/tests/testfile_github/expected_oidc.yaml
@@ -41,10 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
       - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
 
       - name: Assume the testing pipeline user role
         uses: aws-actions/configure-aws-credentials@v1-node16
@@ -74,10 +73,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
       - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
       - run: sam build --template ${SAM_TEMPLATE} --use-container
 
       - name: Assume the testing pipeline user role
@@ -106,10 +104,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
       - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
 
       - name: Build resources
         run: sam build --template ${SAM_TEMPLATE} --use-container
@@ -164,10 +161,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
       - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
       - uses: actions/download-artifact@v2
         with:
           name: packaged-testing.yaml
@@ -210,10 +206,9 @@ jobs:
     # environment: <configured-environment>
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
       - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
       - uses: actions/download-artifact@v2
         with:
           name: packaged-prod.yaml


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Uses the faster `use-installer` introduced in https://github.com/aws-actions/setup-sam/pull/70.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
