### PR TITLE
Chore: Updated upload/download artifact action versions in order to remove warning

### DIFF
--- a/GitHub-Actions/two-stage-pipeline-template/{{cookiecutter.outputDir}}/.github/workflows/pipeline.yaml
+++ b/GitHub-Actions/two-stage-pipeline-template/{{cookiecutter.outputDir}}/.github/workflows/pipeline.yaml
@@ -166,7 +166,7 @@ jobs:
             --region ${TESTING_REGION} \
             --output-template-file packaged-testing.yaml
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: packaged-testing.yaml
           path: packaged-testing.yaml
@@ -194,7 +194,7 @@ jobs:
             --region ${PROD_REGION} \
             --output-template-file packaged-prod.yaml
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: packaged-prod.yaml
           path: packaged-prod.yaml
@@ -208,7 +208,7 @@ jobs:
       - uses: aws-actions/setup-sam@v2
         with:
           use-installer: true
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: packaged-testing.yaml
 
@@ -259,7 +259,7 @@ jobs:
       - uses: aws-actions/setup-sam@v2
         with:
           use-installer: true
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: packaged-prod.yaml
 

--- a/tests/testfile_github/expected_iam.yaml
+++ b/tests/testfile_github/expected_iam.yaml
@@ -133,7 +133,7 @@ jobs:
             --region ${TESTING_REGION} \
             --output-template-file packaged-testing.yaml
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: packaged-testing.yaml
           path: packaged-testing.yaml
@@ -157,7 +157,7 @@ jobs:
             --region ${PROD_REGION} \
             --output-template-file packaged-prod.yaml
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: packaged-prod.yaml
           path: packaged-prod.yaml
@@ -171,7 +171,7 @@ jobs:
       - uses: aws-actions/setup-sam@v2
         with:
           use-installer: true
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: packaged-testing.yaml
 
@@ -218,7 +218,7 @@ jobs:
       - uses: aws-actions/setup-sam@v2
         with:
           use-installer: true
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: packaged-prod.yaml
 

--- a/tests/testfile_github/expected_oidc.yaml
+++ b/tests/testfile_github/expected_oidc.yaml
@@ -128,7 +128,7 @@ jobs:
             --region ${TESTING_REGION} \
             --output-template-file packaged-testing.yaml
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: packaged-testing.yaml
           path: packaged-testing.yaml
@@ -150,7 +150,7 @@ jobs:
             --region ${PROD_REGION} \
             --output-template-file packaged-prod.yaml
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: packaged-prod.yaml
           path: packaged-prod.yaml
@@ -164,7 +164,7 @@ jobs:
       - uses: aws-actions/setup-sam@v2
         with:
           use-installer: true
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: packaged-testing.yaml
 
@@ -209,7 +209,7 @@ jobs:
       - uses: aws-actions/setup-sam@v2
         with:
           use-installer: true
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: packaged-prod.yaml
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR updates the version of actions/upload-artifact and actions/download-artifact from v2 to v3. There are no breaking API changes from upgrading the version of these actions. This change helps remove a warning displayed when executing the pipeline workflow from a GitHub-hosted runner: 

> "Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

I have manually made these changes in a test pipeline generated by AWS SAM cli pipeline, and have confirmed that the workflow completes without errors. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
