### PR TITLE
Fixing build failure of gitlab-ci before_script (#67)

### DIFF
--- a/Gitlab/two-stage-pipeline-template/{{cookiecutter.outputDir}}/.gitlab-ci.yml
+++ b/Gitlab/two-stage-pipeline-template/{{cookiecutter.outputDir}}/.gitlab-ci.yml
@@ -50,7 +50,8 @@ services:
     - docker:19.03.15-dind
 
 before_script:
-  - apk add --update python3 py-pip python3-dev build-base
+  - apk add --update python3 py-pip python3-dev build-base libffi-dev
+  - pip install --upgrade pip
   - pip install awscli aws-sam-cli
 
 stages:


### PR DESCRIPTION
*Issue #, if available:*
[#67](https://github.com/aws/aws-sam-cli-pipeline-init-templates/issues/67)

*Description of changes:*
Added libffi-dev and self upgraded pip in the before_script of gitlab-ci.yml

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
