### PR TITLE
fix: bumping version of AWS CodeBuild image

### DIFF
--- a/AWS-CodePipeline/sam-monorepo-pipeline-template/{{cookiecutter.outputDir}}/codepipeline.yaml
+++ b/AWS-CodePipeline/sam-monorepo-pipeline-template/{{cookiecutter.outputDir}}/codepipeline.yaml
@@ -39,7 +39,7 @@ Parameters:
     Default: "{{cookiecutter.monorepo_ssm_prefix}}"
   CodeBuildImage:
     Type: String
-    Default: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+    Default: aws/codebuild/amazonlinux2-x86_64-standard:5.0
   # Stage 1 Parameters
   TestConfigEnvName:
     Type: String

--- a/AWS-CodePipeline/sam-monorepo-pipeline-template/{{cookiecutter.outputDir}}/pipeline/buildspec_build_package.yml
+++ b/AWS-CodePipeline/sam-monorepo-pipeline-template/{{cookiecutter.outputDir}}/pipeline/buildspec_build_package.yml
@@ -2,7 +2,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      python: 3.9
+      python: 3.11
     commands:
       - pip install --upgrade pip
       - pip install --upgrade awscli aws-sam-cli

--- a/AWS-CodePipeline/sam-monorepo-pipeline-template/{{cookiecutter.outputDir}}/pipeline/buildspec_deploy.yml
+++ b/AWS-CodePipeline/sam-monorepo-pipeline-template/{{cookiecutter.outputDir}}/pipeline/buildspec_deploy.yml
@@ -2,7 +2,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      python: 3.9
+      python: 3.11
     commands:
       - pip install --upgrade pip
       - pip install --upgrade awscli aws-sam-cli


### PR DESCRIPTION
*Issue #, if available:*
#71 

*Description of changes:*
- Updating the CodeBuild image to use the latest supported image - Amazon Linux 2 x86_64 standard:5.0
- Setting runtime version for CodeBuild to 3.11

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
